### PR TITLE
Unused Application::container property

### DIFF
--- a/src/Application.php
+++ b/src/Application.php
@@ -69,13 +69,6 @@ class Application extends Container implements ApplicationContract, HttpKernelIn
     protected $resourcePath;
 
     /**
-     * The container instance.
-     *
-     * @var Container
-     */
-    public $container;
-
-    /**
      * All of the loaded configuration files.
      *
      * @var array


### PR DESCRIPTION
The ``container`` property in ``Application`` class does not seem to be used.