### PR TITLE
Application::register() $provider parameter

### DIFF
--- a/src/Application.php
+++ b/src/Application.php
@@ -209,19 +209,20 @@ class Application extends Container implements ApplicationContract, HttpKernelIn
      */
     public function register($provider, $options = array(), $force = false)
     {
-        if (array_key_exists($provider, $this->loadedProviders)) {
+        if (!$provider instanceof \Illuminate\Support\ServiceProvider) {
+            $provider = new $provider($this);
+        }
+        
+        $class = new \ReflectionClass($provider);
+        $name = $class->getName();
+        if (array_key_exists($name, $this->loadedProviders)) {
             return;
         }
 
-        $this->loadedProviders[$provider] = true;
-
-        $provider = new $provider($this);
+        $this->loadedProviders[$name] = true;
 
         $provider->register();
-
-        if (method_exists($provider, 'boot')) {
-            $provider->boot();
-        }
+        $provider->boot();
     }
 
     /**

--- a/src/Application.php
+++ b/src/Application.php
@@ -29,6 +29,8 @@ use Symfony\Component\HttpFoundation\Response as SymfonyResponse;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Illuminate\Contracts\Foundation\Application as ApplicationContract;
 use Symfony\Component\HttpKernel\Exception\MethodNotAllowedHttpException;
+use ReflectionClass;
+use Illuminate\Support\ServiceProvider;
 
 class Application extends Container implements ApplicationContract, HttpKernelInterface
 {
@@ -209,11 +211,11 @@ class Application extends Container implements ApplicationContract, HttpKernelIn
      */
     public function register($provider, $options = array(), $force = false)
     {
-        if (!$provider instanceof \Illuminate\Support\ServiceProvider) {
+        if (!$provider instanceof ServiceProvider) {
             $provider = new $provider($this);
         }
         
-        $class = new \ReflectionClass($provider);
+        $class = new ReflectionClass($provider);
         $name = $class->getName();
         if (array_key_exists($name, $this->loadedProviders)) {
             return;

--- a/tests/FullApplicationTest.php
+++ b/tests/FullApplicationTest.php
@@ -199,9 +199,21 @@ class ExampleTest extends PHPUnit_Framework_TestCase
         $this->assertEquals('http://lumen.com/foo-bar/1/2', route('bar', ['baz' => 1, 'boom' => 2]));
         $this->assertEquals('http://lumen.com/foo-bar/1/2', route('baz', ['baz' => 1, 'boom' => 2]));
     }
+    
+    public function testRegisterServiceProvider()
+    {
+        $app = new Application;
+        $provider = new LumenTestServiceProvider($app);
+        $app->register($provider);
+    }
 }
 
 class LumenTestService {}
+
+class LumenTestServiceProvider extends Illuminate\Support\ServiceProvider 
+{
+    public function register() {}
+}
 
 class LumenTestMiddleware {
     public function handle($request, $next) {


### PR DESCRIPTION
According to phpdoc for ``Illuminate\Contracts\Foundation\Application::register()`` and ``Laravel\Lumen\Application::register()`` it must be possible to pass instance of ``Illuminate\Support\ServiceProvider`` as first parameter. This pull request makes it really an option.