### PR TITLE
PSR-2 in tests

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -54,7 +54,8 @@
     },
     "autoload": {
         "psr-4": {
-            "Laravel\\Lumen\\": "src/"
+            "Laravel\\Lumen\\": "src/",
+            "Laravel\\Lumen\\Tests\\": "tests/"
         },
         "classmap": [
             "src/Foundation"

--- a/tests/FullApplicationTest.php
+++ b/tests/FullApplicationTest.php
@@ -1,8 +1,10 @@
 <?php
+namespace Laravel\Lumen\Tests;
 
 use Mockery as m;
 use Illuminate\Http\Request;
 use Laravel\Lumen\Application;
+use PHPUnit_Framework_TestCase;
 
 class ExampleTest extends PHPUnit_Framework_TestCase
 {
@@ -39,6 +41,7 @@ class ExampleTest extends PHPUnit_Framework_TestCase
 
         $response = $app->handle(Request::create('/', 'GET'));
 
+        var_dump($response->getContent());
         $this->assertEquals(200, $response->getStatusCode());
         $this->assertEquals('Middleware', $response->getContent());
     }
@@ -54,7 +57,7 @@ class ExampleTest extends PHPUnit_Framework_TestCase
             return response('Hello World');
         });
 
-        $app->get('/foo', ['middleware' => 'foo', function() {
+        $app->get('/foo', ['middleware' => 'foo', function () {
             return response('Hello World');
         }]);
 
@@ -74,13 +77,13 @@ class ExampleTest extends PHPUnit_Framework_TestCase
 
         $app->routeMiddleware(['foo' => 'LumenTestMiddleware']);
 
-        $app->group(['middleware' => 'foo'], function($app) {
+        $app->group(['middleware' => 'foo'], function ($app) {
             $app->get('/', function () {
                 return response('Hello World');
             });
         });
 
-        $app->get('/foo', function() {
+        $app->get('/foo', function () {
             return response('Hello World');
         });
 
@@ -97,7 +100,10 @@ class ExampleTest extends PHPUnit_Framework_TestCase
     public function testNotFoundResponse()
     {
         $app = new Application;
-        $app->instance('Illuminate\Contracts\Debug\ExceptionHandler', $mock = m::mock('Laravel\Lumen\Exceptions\Handler[report]'));
+        $app->instance(
+            'Illuminate\Contracts\Debug\ExceptionHandler',
+            $mock = m::mock('Laravel\Lumen\Exceptions\Handler[report]')
+        );
         $mock->shouldIgnoreMissing();
 
         $app->get('/', function () {
@@ -113,7 +119,10 @@ class ExampleTest extends PHPUnit_Framework_TestCase
     public function testMethodNotAllowedResponse()
     {
         $app = new Application;
-        $app->instance('Illuminate\Contracts\Debug\ExceptionHandler', $mock = m::mock('Laravel\Lumen\Exceptions\Handler[report]'));
+        $app->instance(
+            'Illuminate\Contracts\Debug\ExceptionHandler',
+            $mock = m::mock('Laravel\Lumen\Exceptions\Handler[report]')
+        );
         $mock->shouldIgnoreMissing();
 
         $app->post('/', function () {
@@ -143,9 +152,9 @@ class ExampleTest extends PHPUnit_Framework_TestCase
     {
         $app = new Application;
 
-        require_once __DIR__.'/fixtures/TestController.php';
+//        require_once __DIR__.'/fixtures/TestController.php';
 
-        $app->group(['namespace' => 'Lumen\Tests'], function($app) {
+        $app->group(['namespace' => 'Lumen\Tests'], function ($app) {
             $app->get('/', 'TestController@action');
         });
 
@@ -162,11 +171,11 @@ class ExampleTest extends PHPUnit_Framework_TestCase
         $app->instance('request', Request::create('http://lumen.com', 'GET'));
         unset($app->availableBindings['request']);
 
-        $app->get('/foo-bar', ['as' => 'foo', function() {
+        $app->get('/foo-bar', ['as' => 'foo', function () {
             //
         }]);
 
-        $app->get('/foo-bar/{baz}/{boom}', ['as' => 'bar', function() {
+        $app->get('/foo-bar/{baz}/{boom}', ['as' => 'bar', function () {
             //
         }]);
 
@@ -182,15 +191,15 @@ class ExampleTest extends PHPUnit_Framework_TestCase
         $app->instance('request', Request::create('http://lumen.com', 'GET'));
         unset($app->availableBindings['request']);
 
-        $app->get('/foo-bar', ['as' => 'foo', function() {
+        $app->get('/foo-bar', ['as' => 'foo', function () {
             //
         }]);
 
-        $app->get('/foo-bar/{baz:[0-9]+}/{boom}', ['as' => 'bar', function() {
+        $app->get('/foo-bar/{baz:[0-9]+}/{boom}', ['as' => 'bar', function () {
             //
         }]);
 
-        $app->get('/foo-bar/{baz:[0-9]+}/{boom:[0-9]+}', ['as' => 'baz', function() {
+        $app->get('/foo-bar/{baz:[0-9]+}/{boom:[0-9]+}', ['as' => 'baz', function () {
             //
         }]);
 
@@ -198,23 +207,5 @@ class ExampleTest extends PHPUnit_Framework_TestCase
         $this->assertEquals('http://lumen.com/foo-bar', route('foo'));
         $this->assertEquals('http://lumen.com/foo-bar/1/2', route('bar', ['baz' => 1, 'boom' => 2]));
         $this->assertEquals('http://lumen.com/foo-bar/1/2', route('baz', ['baz' => 1, 'boom' => 2]));
-    }
-}
-
-class LumenTestService {}
-
-class LumenTestMiddleware {
-    public function handle($request, $next) {
-          return response('Middleware');
-    }
-}
-
-class LumenTestController {
-    public $service;
-    public function __construct(LumenTestService $service) {
-        $this->service = $service;
-    }
-    public function action() {
-        return response(__CLASS__);
     }
 }

--- a/tests/FullApplicationTest.php
+++ b/tests/FullApplicationTest.php
@@ -6,7 +6,7 @@ use Illuminate\Http\Request;
 use Laravel\Lumen\Application;
 use PHPUnit_Framework_TestCase;
 
-class ExampleTest extends PHPUnit_Framework_TestCase
+class FullApplicationTest extends PHPUnit_Framework_TestCase
 {
     public function tearDown()
     {

--- a/tests/FullApplicationTest.php
+++ b/tests/FullApplicationTest.php
@@ -33,7 +33,7 @@ class ExampleTest extends PHPUnit_Framework_TestCase
     {
         $app = new Application;
 
-        $app->middleware(['LumenTestMiddleware']);
+        $app->middleware(['Laravel\Lumen\Tests\LumenTestMiddleware']);
 
         $app->get('/', function () {
             return response('Hello World');
@@ -41,7 +41,6 @@ class ExampleTest extends PHPUnit_Framework_TestCase
 
         $response = $app->handle(Request::create('/', 'GET'));
 
-        var_dump($response->getContent());
         $this->assertEquals(200, $response->getStatusCode());
         $this->assertEquals('Middleware', $response->getContent());
     }
@@ -51,7 +50,7 @@ class ExampleTest extends PHPUnit_Framework_TestCase
     {
         $app = new Application;
 
-        $app->routeMiddleware(['foo' => 'LumenTestMiddleware']);
+        $app->routeMiddleware(['foo' => 'Laravel\Lumen\Tests\LumenTestMiddleware']);
 
         $app->get('/', function () {
             return response('Hello World');
@@ -75,7 +74,7 @@ class ExampleTest extends PHPUnit_Framework_TestCase
     {
         $app = new Application;
 
-        $app->routeMiddleware(['foo' => 'LumenTestMiddleware']);
+        $app->routeMiddleware(['foo' => 'Laravel\Lumen\Tests\LumenTestMiddleware']);
 
         $app->group(['middleware' => 'foo'], function ($app) {
             $app->get('/', function () {
@@ -139,12 +138,12 @@ class ExampleTest extends PHPUnit_Framework_TestCase
     {
         $app = new Application;
 
-        $app->get('/', 'LumenTestController@action');
+        $app->get('/', 'Laravel\Lumen\Tests\LumenTestController@action');
 
         $response = $app->handle(Request::create('/', 'GET'));
 
         $this->assertEquals(200, $response->getStatusCode());
-        $this->assertEquals('LumenTestController', $response->getContent());
+        $this->assertEquals('Laravel\Lumen\Tests\LumenTestController', $response->getContent());
     }
 
 
@@ -152,16 +151,14 @@ class ExampleTest extends PHPUnit_Framework_TestCase
     {
         $app = new Application;
 
-//        require_once __DIR__.'/fixtures/TestController.php';
-
-        $app->group(['namespace' => 'Lumen\Tests'], function ($app) {
-            $app->get('/', 'TestController@action');
+        $app->group(['namespace' => ''], function ($app) {
+            $app->get('/', 'Laravel\Lumen\Tests\TestController@action');
         });
 
         $response = $app->handle(Request::create('/', 'GET'));
 
         $this->assertEquals(200, $response->getStatusCode());
-        $this->assertEquals('Lumen\Tests\TestController', $response->getContent());
+        $this->assertEquals('Laravel\Lumen\Tests\TestController', $response->getContent());
     }
 
 

--- a/tests/FullApplicationTest.php
+++ b/tests/FullApplicationTest.php
@@ -151,8 +151,8 @@ class ExampleTest extends PHPUnit_Framework_TestCase
     {
         $app = new Application;
 
-        $app->group(['namespace' => ''], function ($app) {
-            $app->get('/', 'Laravel\Lumen\Tests\TestController@action');
+        $app->group(['namespace' => 'Laravel\Lumen\Tests'], function ($app) {
+            $app->get('/', 'TestController@action');
         });
 
         $response = $app->handle(Request::create('/', 'GET'));

--- a/tests/LumenTestController.php
+++ b/tests/LumenTestController.php
@@ -1,0 +1,15 @@
+<?php
+namespace Laravel\Lumen\Tests;
+
+class LumenTestController
+{
+    public $service;
+    public function __construct(LumenTestService $service)
+    {
+        $this->service = $service;
+    }
+    public function action()
+    {
+        return response(__CLASS__);
+    }
+}

--- a/tests/LumenTestMiddleware.php
+++ b/tests/LumenTestMiddleware.php
@@ -1,0 +1,10 @@
+<?php
+namespace Laravel\Lumen\Tests;
+
+class LumenTestMiddleware
+{
+    public function handle($request, $next)
+    {
+        return response('Middleware');
+    }
+}

--- a/tests/LumenTestService.php
+++ b/tests/LumenTestService.php
@@ -1,0 +1,6 @@
+<?php
+namespace Laravel\Lumen\Tests;
+
+class LumenTestService
+{
+}

--- a/tests/TestController.php
+++ b/tests/TestController.php
@@ -1,0 +1,9 @@
+<?php namespace Laravel\Lumen\Tests;
+
+class TestController
+{
+    public function action()
+    {
+        return __CLASS__;
+    }
+}

--- a/tests/fixtures/TestController.php
+++ b/tests/fixtures/TestController.php
@@ -1,7 +1,0 @@
-<?php namespace Lumen\Tests;
-
-class TestController {
-    public function action() {
-        return __CLASS__;
-    }
-}


### PR DESCRIPTION
Following changes have been applied:
* each class lives in its own file (PSR-1);
* each class has a namespace defined (PSR-1);
* lines longer then 120 lines have been broken into multiple lines (PSR-2);
* ExampleTest class is renamed to FullApplicationTest (PSR-4 - yes, I know it is not part of PSR-2 but it's close enough to me).

Tests had to be modified a bit and TestController file moved to another location to accommodate changes listed above.

Some additional issues have been identiefied:
* ``Laravel\Lumen\Application::handle()`` method is beind used in tests while in real world ``Laravel\Lumen\Application::run()`` [will be used](https://github.com/laravel/lumen/blob/master/public/index.php#L28);