### PR TITLE
Add the awesome laravel key generate command

### DIFF
--- a/src/Console/Commands/KeyGenerateCommmand.php
+++ b/src/Console/Commands/KeyGenerateCommmand.php
@@ -29,7 +29,7 @@ class KeyGenerateCommand extends Command {
 	{
 		$key = $this->getRandomKey();
 
-		if($this->confirm('You have uncomment Dotenv::load in boostrap/app.php? [yes|no]')) {
+		if($this->confirm('Have you uncommented Dotenv::load in bootstrap/app.php? [yes|no]')) {
 			if ($this->option('show')) {
 				return $this->line('<comment>'.$key.'</comment>');
 			}

--- a/src/Console/Commands/KeyGenerateCommmand.php
+++ b/src/Console/Commands/KeyGenerateCommmand.php
@@ -1,0 +1,75 @@
+<?php namespace Laravel\Lumen\Console\Commands;
+
+use Illuminate\Support\Str;
+use Illuminate\Console\Command;
+use Symfony\Component\Console\Input\InputOption;
+
+class KeyGenerateCommand extends Command {
+
+	/**
+	 * The console command name.
+	 *
+	 * @var string
+	 */
+	protected $name = 'key:generate';
+
+	/**
+	 * The console command description.
+	 *
+	 * @var string
+	 */
+	protected $description = "Set the application key";
+
+	/**
+	 * Execute the console command.
+	 *
+	 * @return void
+	 */
+	public function fire()
+	{
+		$key = $this->getRandomKey();
+
+		if($this->confirm('You have uncomment Dotenv::load in boostrap/app.php? [yes|no]')) {
+			if ($this->option('show')) {
+				return $this->line('<comment>'.$key.'</comment>');
+			}
+
+			$path = base_path('.env');
+
+			if (file_exists($path))	{
+				file_put_contents($path, str_replace(
+					env('APP_KEY'), $key, file_get_contents($path)
+				));
+			}
+
+			$this->laravel['config']['app.key'] = $key;
+			$this->info("Application key [$key] set successfully.");
+		} else {
+			$this->info("Please uncomment Dotenv Line in boostrap/app.php and try again.");
+		}
+
+		
+	}
+
+	/**
+	 * Generate a random key for the application.
+	 *
+	 * @return string
+	 */
+	protected function getRandomKey()
+	{
+		return Str::random(32);
+	}
+	
+	/**
+	 * Get the console command options.
+	 *
+	 * @return array
+	 */
+	protected function getOptions()
+	{
+		return array(
+			array('show', null, InputOption::VALUE_NONE, 'Simply display the key instead of modifying files.'),
+		);
+	}
+}

--- a/src/Console/Kernel.php
+++ b/src/Console/Kernel.php
@@ -164,6 +164,7 @@ class Kernel implements KernelContract
                 'Illuminate\Console\Scheduling\ScheduleRunCommand',
                 'Laravel\Lumen\Console\Commands\MakeCommand',
                 'Laravel\Lumen\Console\Commands\ServeCommand',
+                'Laravel\Lumen\Console\Commands\KeyGenerateCommand',
             ]);
         } else {
             return $this->commands;


### PR DESCRIPTION
Please add this PR for enable the awesome command for generating app keys.

I have changed a little bit from the laravel version. No need for app.php in config folder. Overwrite APP_KEY in .env file easy