### PR TITLE
Fix error 404 if not run Lumen in root

### DIFF
--- a/src/Application.php
+++ b/src/Application.php
@@ -1324,9 +1324,9 @@ class Application extends Container implements ApplicationContract, HttpKernelIn
     public function getPathInfo()
     {
         $query = isset($_SERVER['QUERY_STRING']) ? $_SERVER['QUERY_STRING'] : '';
-        $folder = dirname($_SERVER['SCRIPT_NAME']).'/';
+        $folder = dirname($_SERVER['SCRIPT_NAME']);
         $uri = $_SERVER['REQUEST_URI'];
-        if (strpos($uri, $folder) === 0) {
+        if ($folder != $uri && strpos($uri, $folder) === 0) {
             $uri = substr($uri, strlen($folder));
         }
         return '/'.ltrim(str_replace('?'.$query, '', $uri), '/');

--- a/src/Application.php
+++ b/src/Application.php
@@ -1324,8 +1324,11 @@ class Application extends Container implements ApplicationContract, HttpKernelIn
     public function getPathInfo()
     {
         $query = isset($_SERVER['QUERY_STRING']) ? $_SERVER['QUERY_STRING'] : '';
-        $uri = str_replace(dirname($_SERVER['SCRIPT_NAME']).'/', '', $_SERVER['REQUEST_URI']);
-
+        $folder = dirname($_SERVER['SCRIPT_NAME']).'/';
+        $uri = $_SERVER['REQUEST_URI'];
+        if (strpos($uri, $folder) === 0) {
+            $uri = substr($uri, strlen($folder));
+        }
         return '/'.ltrim(str_replace('?'.$query, '', $uri), '/');
     }
 

--- a/src/Application.php
+++ b/src/Application.php
@@ -1324,8 +1324,9 @@ class Application extends Container implements ApplicationContract, HttpKernelIn
     public function getPathInfo()
     {
         $query = isset($_SERVER['QUERY_STRING']) ? $_SERVER['QUERY_STRING'] : '';
+        $uri = str_replace(dirname($_SERVER['SCRIPT_NAME']).'/', '', $_SERVER['REQUEST_URI']);
 
-        return '/'.ltrim(str_replace('?'.$query, '', $_SERVER['REQUEST_URI']), '/');
+        return '/'.ltrim(str_replace('?'.$query, '', $uri), '/');
     }
 
     /**


### PR DESCRIPTION
`getPathInfo()` give wrong uri if Lumen run in a sub folder, this PR to resolve the problem.