### PR TITLE
Fix error when using PHP built-in server

### DIFF
--- a/src/Application.php
+++ b/src/Application.php
@@ -1435,7 +1435,7 @@ class Application extends Container implements ApplicationContract, HttpKernelIn
      */
     public function runningInConsole()
     {
-        return php_sapi_name() == 'cli';
+        return substr(php_sapi_name(), 0, 3) == 'cli';
     }
 
     /**


### PR DESCRIPTION
When using `php -S localhost:1234 server.php` to run Lumen, php_sapi_name is `cli-server` instead of `cli` (at least, on my Windows PC). This PR makes sure both are recognized as CLI and also allows other variants of cli-*.