### PR TITLE
Additional method to register a  controller route

### DIFF
--- a/src/Application.php
+++ b/src/Application.php
@@ -872,6 +872,38 @@ class Application extends Container implements ApplicationContract, HttpKernelIn
 
         return $this;
     }
+    
+    /**
+     * Register a controller route with the application.
+     *
+     * @param string $uri
+     * @param string $class
+     * @param string $namePrefix
+     *
+     */
+    public function controller($uri, $className, $namePrefix = '')
+    {
+        static $patternMethod = '#^
+            (GET|POST|ANY|PATCH|PUT|DELETE|HEAD|CONNECT|OPTIONS|TRACE)
+            ((?!MiddlewareForMethod)[\w_]+)+
+        $#ix';
+
+        $class = new ReflectionClass($className);
+        $namePrefix = $namePrefix ?: strtolower($class->getShortName());
+
+        foreach ($class->getMethods(ReflectionMethod::IS_PUBLIC) as $method) {
+            $methodName = $method->getName();
+            if (preg_match($patternMethod, $methodName, $match)) {
+                $viaMethod = strtoupper($match[1]);
+                $action = strtolower($match[2]);
+                $pattern = sprintf('/{action:%s}', $action == 'index' ? 'index|' : $action);
+
+                $this->addRoute($viaMethod, $uri.$pattern, [
+                                'uses' => $className.'@'.$methodName,
+                                'as' => $namePrefix.'.'.$action, ]);
+            }
+        }
+    }
 
     /**
      * Add a route to the collection.


### PR DESCRIPTION
I know that purpose of Lumen is performance, and i love it. 
But for me and many people, not only use micro-framework to build restAPI, still need to build a full features web application with backend.
For building routes for backend, i think controller route is very helpful because repeat multiple times with $app->get(), $app->post() seem very stupid :(

Should consider to addition this PR. @Otwell