### PR TITLE
fix error 404 if not run Lumen in root [2]

### DIFF
--- a/src/Application.php
+++ b/src/Application.php
@@ -1324,8 +1324,12 @@ class Application extends Container implements ApplicationContract, HttpKernelIn
     public function getPathInfo()
     {
         $query = isset($_SERVER['QUERY_STRING']) ? $_SERVER['QUERY_STRING'] : '';
-
-        return '/'.ltrim(str_replace('?'.$query, '', $_SERVER['REQUEST_URI']), '/');
+        $folder = dirname($_SERVER['SCRIPT_NAME']);
+        $uri = $_SERVER['REQUEST_URI'];
+        if ($folder != $uri && strpos($uri, $folder) === 0) {
+            $uri = substr($uri, strlen($folder));
+        }
+        return '/'.ltrim(str_replace('?'.$query, '', $uri), '/');
     }
 
     /**


### PR DESCRIPTION
Previous PR, i have missing a case that if uri contains a path like sub-folder name