### PR TITLE
Route groups should be inherit parent group attributes

### DIFF
--- a/src/Application.php
+++ b/src/Application.php
@@ -782,12 +782,12 @@ class Application extends Container implements ApplicationContract, HttpKernelIn
      */
     public function group(array $attributes, Closure $callback)
     {
-        $previous_attributes   = $this->groupAttributes;
+        $previousAttributes = $this->groupAttributes;
         $this->groupAttributes = $this->mergeParentGroupAttributes($attributes);
 
         call_user_func($callback, $this);
 
-        $this->groupAttributes = $previous_attributes;
+        $this->groupAttributes = $previousAttributes;
     }
 
     /**
@@ -918,13 +918,12 @@ class Application extends Container implements ApplicationContract, HttpKernelIn
     /**
      * Merge parent group attributes.
      *
-     * @param array $attributes
+     * @param  array $attributes
      * @return array
      */
     protected function mergeParentGroupAttributes(array $attributes)
     {
         if (isset($this->groupAttributes)) {
-
             return array_merge($this->groupAttributes, $attributes);
         }
 

--- a/src/Application.php
+++ b/src/Application.php
@@ -782,11 +782,12 @@ class Application extends Container implements ApplicationContract, HttpKernelIn
      */
     public function group(array $attributes, Closure $callback)
     {
-        $this->groupAttributes = $attributes;
+        $previous_attributes   = $this->groupAttributes;
+        $this->groupAttributes = $this->mergeParentGroupAttributes($attributes);
 
         call_user_func($callback, $this);
 
-        $this->groupAttributes = null;
+        $this->groupAttributes = $previous_attributes;
     }
 
     /**
@@ -912,6 +913,22 @@ class Application extends Container implements ApplicationContract, HttpKernelIn
         }
 
         return $action;
+    }
+
+    /**
+     * Merge parent group attributes.
+     *
+     * @param array $attributes
+     * @return array
+     */
+    protected function mergeParentGroupAttributes(array $attributes)
+    {
+        if (isset($this->groupAttributes)) {
+
+            return array_merge($this->groupAttributes, $attributes);
+        }
+
+        return $attributes;
     }
 
     /**


### PR DESCRIPTION
The current situation, if we have group inside another group, the child group is not able to get parent attributes. It is important since we can using namespacing group. 

the code example will explain the rest. 

```php
$app->group( [ 'namespace' => 'App\Http\Controllers' ], function ( $app ){
    $app->get( '/', [
        'uses' => 'SomeController@getIndex'
    ] );
    
    $app->group( [ 'middleware' => 'auth' ], function ( $app ){
        // this will be failed because parent group parameters has been nulled
        $app->get( 'foo', [
            'uses' => 'FooController@getIndex'
        ] );
    });

    $app->group( [ 'middleware' => 'auth.basic' ], function ( $app ){
        $app->get( 'bar', [
            'uses' => 'BarController@getIndex'
        ] );
    } );
});
```

if we print the routes, we will get this
```sh
array:3 [
  "GET/" => array:3 [
    "method" => "GET"
    "uri" => "/"
    "action" => array:1 [
      "uses" => "App\Http\Controllers\SomeController@getIndex"
    ]
  ]
  "GET/foo" => array:3 [
    "method" => "GET"
    "uri" => "/foo"
    "action" => array:2 [
      "uses" => "FooController@getIndex"
      "middleware" => "auth"
    ]
  ]
  "GET/bar" => array:3 [
    "method" => "GET"
    "uri" => "/bar"
    "action" => array:2 [
      "uses" => "BarController@getIndex"
      "middleware" => "auth.basic"
    ]
  ]
]
```

 I hope this PR will fix this
