### PR TITLE
Support built-in PHP server

### DIFF
--- a/src/Application.php
+++ b/src/Application.php
@@ -1340,7 +1340,7 @@ class Application extends Container implements ApplicationContract, HttpKernelIn
             return $this->basePath.($path ? '/'.$path : $path);
         }
 
-        if ($this->runningInConsole()) {
+        if ($this->runningInConsole() || php_sapi_name() === 'cli-server') {
             $this->basePath = getcwd();
         } else {
             $this->basePath = realpath(getcwd().'/../');


### PR DESCRIPTION
Second try at fixing errors when using the built-in PHP server + `server.php` router file with Lumen.