### PR TITLE
Add baseUrl to support sub-directory setups

### DIFF
--- a/src/Application.php
+++ b/src/Application.php
@@ -77,6 +77,13 @@ class Application extends Container implements ApplicationContract, HttpKernelIn
     protected $loadedConfigurations = [];
 
     /**
+     * The base url relative to the domain root.
+     *
+     * @var string
+     */
+    protected $baseUrl = '/';
+
+    /**
      * All of the routes waiting to be registered.
      *
      * @var array
@@ -718,6 +725,20 @@ class Application extends Container implements ApplicationContract, HttpKernelIn
     }
 
     /**
+     * Get or set the base url relative to the domain root.
+     *
+     * @param  string|null  $url
+     * @return string
+     */
+    public function baseUrl($url = null)
+    {
+        if(is_string($url)){
+            $this->baseUrl = '/'.trim($url, '/').'/';
+        }
+        return $this->baseUrl;
+    }
+
+    /**
      * Get the path to the given configuration file.
      *
      * @param  string  $name
@@ -1324,8 +1345,11 @@ class Application extends Container implements ApplicationContract, HttpKernelIn
     public function getPathInfo()
     {
         $query = isset($_SERVER['QUERY_STRING']) ? $_SERVER['QUERY_STRING'] : '';
+        $url = ltrim(str_replace('?'.$query, '', $_SERVER['REQUEST_URI']), '/');
 
-        return '/'.ltrim(str_replace('?'.$query, '', $_SERVER['REQUEST_URI']), '/');
+        $url = substr($url, strlen($this->baseUrl) - 1);
+
+        return '/'.$url;
     }
 
     /**


### PR DESCRIPTION
I know this has been discussed [here](https://github.com/laravel/lumen-framework/pull/22) and [here](https://github.com/laravel/lumen-framework/pull/21) but I think I've found a quite nice solution to make it possible to run Lumen in a sub directory. Especially for something that provides a micro-service I think it would be quite nice to have this flexibility.

Instead trying to figure out the base URL or rely on the symfony request class for this I thought why not just make it configurable. So I've added a method that can be easily used from `bootstrap/app.php` to set a base URL if necessary. Like this:

    $app->baseUrl('api');