### PR TITLE
Fix Log resolver

### DIFF
--- a/src/Application.php
+++ b/src/Application.php
@@ -526,7 +526,7 @@ class Application extends Container implements ApplicationContract, HttpKernelIn
      */
     protected function registerLogBindings()
     {
-        $this->singleton('log', function () {
+        $this->singleton('Psr\Log\LoggerInterface', function () {
             return new Logger('lumen', [$this->getMonologHandler()]);
         });
     }
@@ -1496,6 +1496,7 @@ class Application extends Container implements ApplicationContract, HttpKernelIn
             'request' => 'Illuminate\Http\Request',
             'Illuminate\Session\SessionManager' => 'session',
             'Illuminate\Contracts\View\Factory' => 'view',
+            'log' => 'Psr\Log\LoggerInterface',
         ];
     }
 
@@ -1529,6 +1530,7 @@ class Application extends Container implements ApplicationContract, HttpKernelIn
         'Illuminate\Contracts\Filesystem\Factory' => 'registerFilesBindings',
         'hash' => 'registerHashBindings',
         'Illuminate\Contracts\Hashing\Hasher' => 'registerHashBindings',
+        'Psr\Log\LoggerInterface' => 'registerLogBindings',
         'log' => 'registerLogBindings',
         'mailer' => 'registerMailBindings',
         'Illuminate\Contracts\Mail\Mailer' => 'registerMailBindings',

--- a/src/Application.php
+++ b/src/Application.php
@@ -526,7 +526,7 @@ class Application extends Container implements ApplicationContract, HttpKernelIn
      */
     protected function registerLogBindings()
     {
-        $this->singleton('Psr\Log\LoggerInterface', function () {
+        $this->singleton('log', function () {
             return new Logger('lumen', [$this->getMonologHandler()]);
         });
     }
@@ -1529,7 +1529,7 @@ class Application extends Container implements ApplicationContract, HttpKernelIn
         'Illuminate\Contracts\Filesystem\Factory' => 'registerFilesBindings',
         'hash' => 'registerHashBindings',
         'Illuminate\Contracts\Hashing\Hasher' => 'registerHashBindings',
-        'Psr\Log\LoggerInterface' => 'registerLogBindings',
+        'log' => 'registerLogBindings',
         'mailer' => 'registerMailBindings',
         'Illuminate\Contracts\Mail\Mailer' => 'registerMailBindings',
         'queue' => 'registerQueueBindings',


### PR DESCRIPTION
Currently, when using any of the `Log` facade methods we will get a fatal error:
```Fatal error: Call to undefined method Illuminate\Support\Facades\Log::error() in vendor/illuminate/support/Facades/Facade.php on line 210```

This is due to the Laravel `Log` facade `getFacadeAccessor()` method returning `log`, while in the `Application.php` we have `Psr\Log\LoggerInterface` instead.

This pull request fixes that.