### PR TITLE
Check error_reporting before throwing ErrorException

### DIFF
--- a/src/Application.php
+++ b/src/Application.php
@@ -274,7 +274,9 @@ class Application extends Container implements ApplicationContract, HttpKernelIn
         error_reporting(-1);
 
         set_error_handler(function ($level, $message, $file = '', $line = 0) {
-            throw new ErrorException($message, 0, $level, $file, $line);
+            if (error_reporting() & $level) {
+                throw new ErrorException($message, 0, $level, $file, $line);
+            }
         });
 
         set_exception_handler(function ($e) {


### PR DESCRIPTION
I'm a complete novice when it comes to PHP, so this pull request is probably garbage, but here goes...

I've migrated a Laravel app to Lumen and one of the side effects was that `error_reporting` changes were ignored.

For example, I had something like this:

```php
error_reporting(E_ALL ^ E_DEPRECATED);

// Use a legacy package that would normally trigger a PHP deprecated warning
deprecated_package();

error_reporting(-1);
```

Even if I would temporarily disable deprecated warnings, Lumen would still catch them and report them (and break the app). In Laravel it worked.

Laravel seems to [check `error_reporting` level before throwing an exception](https://github.com/laravel/framework/blob/89fcc958286c4105fbe24bf103f6c4d1fc2d6a5e/src/Illuminate/Foundation/Bootstrap/HandleExceptions.php#L55-L58). My pull request should make Lumen do the same.