### PR TITLE
Fix basepath for artisan serve

### DIFF
--- a/src/Application.php
+++ b/src/Application.php
@@ -1338,11 +1338,7 @@ class Application extends Container implements ApplicationContract, HttpKernelIn
             return $this->basePath.($path ? '/'.$path : $path);
         }
 
-        if ($this->runningInConsole() || php_sapi_name() === 'cli-server') {
-            $this->basePath = getcwd();
-        } else {
-            $this->basePath = realpath(getcwd().'/../');
-        }
+        $this->basePath = realpath(getcwd().'/../');
 
         return $this->basePath($path);
     }


### PR DESCRIPTION
Running from `php artisan serve` in `v5.0.3` causes:

```
Fatal error: Uncaught exception 'UnexpectedValueException' with message 'The stream or file "<redacted>/public/storage/logs/lumen.log" could not be opened: failed to open stream: No such file or directory' 
```

I fixed the issue by removing these lines however I'm sure they are there for a reason. I've not done anything other than install, create a `home.php` view then `return view('home');` `in routes.php`