### PR TITLE
Register facades for command, useful for migration commands.

### DIFF
--- a/src/Application.php
+++ b/src/Application.php
@@ -1443,6 +1443,8 @@ class Application extends Container implements ApplicationContract, HttpKernelIn
      */
     public function prepareForConsoleCommand()
     {
+        $this->withFacades();
+
         $this->make('cache');
         $this->make('queue');
 


### PR DESCRIPTION
Replaces laravel/framework#8513

Signed-off-by: crynobone <crynobone@gmail.com>