### PR TITLE
Add support to use redis cache driver

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,6 +32,7 @@
         "illuminate/http": "5.0.*",
         "illuminate/pagination": "5.0.*",
         "illuminate/queue": "5.0.*",
+        "illuminate/redis": "5.0.*",
         "illuminate/session": "5.0.*",
         "illuminate/support": "5.0.*",
         "illuminate/translation": "5.0.*",

--- a/config/cache.php
+++ b/config/cache.php
@@ -70,6 +70,6 @@ return [
     |
     */
 
-    'prefix' => 'laravel',
+    'prefix' => env('CACHE_PREFIX', 'laravel'),
 
 ];

--- a/config/database.php
+++ b/config/database.php
@@ -121,8 +121,8 @@ return [
         'cluster' => false,
 
         'default' => [
-            'host'     => '127.0.0.1',
-            'port'     => 6379,
+            'host'     => env('REDIS_HOST', '127.0.0.1'),
+            'port'     => env('REDIS_PORT', 6379),
             'database' => 0,
         ],
 

--- a/src/Application.php
+++ b/src/Application.php
@@ -396,6 +396,10 @@ class Application extends Container implements ApplicationContract, HttpKernelIn
         $this->singleton('cache', function () {
             return $this->loadComponent('cache', 'Illuminate\Cache\CacheServiceProvider');
         });
+
+        $this->singleton('cache.store', function () {
+            return $this->loadComponent('cache', 'Illuminate\Cache\CacheServiceProvider', 'cache.store');
+        });
     }
 
     /**
@@ -571,6 +575,18 @@ class Application extends Container implements ApplicationContract, HttpKernelIn
 
         $this->singleton('queue.connection', function () {
             return $this->loadComponent('queue', 'Illuminate\Queue\QueueServiceProvider', 'queue.connection');
+        });
+    }
+
+    /**
+     * Register container bindings for the application.
+     *
+     * @return void
+     */
+    protected function registerRedisBindings()
+    {
+        $this->singleton('redis', function () {
+            return $this->loadComponent('redis', 'Illuminate\Redis\RedisServiceProvider');
         });
     }
 
@@ -1497,6 +1513,7 @@ class Application extends Container implements ApplicationContract, HttpKernelIn
             'Illuminate\Contracts\Mail\Mailer' => 'mailer',
             'Illuminate\Contracts\Queue\Queue' => 'queue.connection',
             'request' => 'Illuminate\Http\Request',
+            'Illuminate\Contracts\Redis\Database' => 'redis',
             'Illuminate\Session\SessionManager' => 'session',
             'Illuminate\Contracts\View\Factory' => 'view',
         ];
@@ -1539,6 +1556,7 @@ class Application extends Container implements ApplicationContract, HttpKernelIn
         'queue' => 'registerQueueBindings',
         'queue.connection' => 'registerQueueBindings',
         'Illuminate\Contracts\Queue\Queue' => 'registerQueueBindings',
+        'redis' => 'registerRedisBindings',
         'request' => 'registerRequestBindings',
         'Illuminate\Http\Request' => 'registerRequestBindings',
         'session' => 'registerSessionBindings',


### PR DESCRIPTION
Allow the `redis` cache driver to be able to be used as per the documentation.

Have also added env config options for redis host/port and the cache prefix.