### PR TITLE
Fix basePath for artisan serve command

### DIFF
--- a/src/Application.php
+++ b/src/Application.php
@@ -1338,7 +1338,7 @@ class Application extends Container implements ApplicationContract, HttpKernelIn
             return $this->basePath.($path ? '/'.$path : $path);
         }
 
-        if ($this->runningInConsole() || php_sapi_name() === 'cli-server') {
+        if ($this->runningInConsole()) {
             $this->basePath = getcwd();
         } else {
             $this->basePath = realpath(getcwd().'/../');


### PR DESCRIPTION
The bug was introduced in https://github.com/laravel/lumen-framework/commit/e5e4ac6e082c153c5f9581f6236222a2516b6f26.

The PHP built-in server still works fine if executed with the correct document root (e.g. `php -t path_to_my_lumen_app/public -S 127.0.0.1:8000`).