### PR TITLE
Add Route Parameter Helper

### DIFF
--- a/src/helpers.php
+++ b/src/helpers.php
@@ -276,6 +276,22 @@ if (! function_exists('route')) {
     }
 }
 
+if (! function_exists('route_parameter')) {
+    /**
+     * Get a given parameter from the route.
+     *
+     * @param  string $name
+     * @param  mixed  $default
+     * @return string|object
+     */
+    function route_parameter($name, $default = null)
+    {
+        $routeInfo = app('request')->route();
+
+        return array_get($routeInfo[2], $name, $default);
+    }
+}
+
 if (! function_exists('session')) {
     /**
      * Get / set the specified session value.


### PR DESCRIPTION
Helper to get route parameter. Comes handy in middleware and elsewhere.
Available in Laravel. But was missing in Lumen.