### PR TITLE
Changed the default cache driver to file.

### DIFF
--- a/config/cache.php
+++ b/config/cache.php
@@ -13,7 +13,7 @@ return [
     |
     */
 
-    'default' => env('CACHE_DRIVER', 'memcached'),
+    'default' => env('CACHE_DRIVER', 'file'),
 
     /*
     |--------------------------------------------------------------------------


### PR DESCRIPTION
Doesn't it make sense to keep the default driver as 'file' (as in Laravel) since not everyone will have memcached enabled (especially in windows)