### PR TITLE
Fix trailing slash

### DIFF
--- a/src/Application.php
+++ b/src/Application.php
@@ -1348,7 +1348,7 @@ class Application extends Container implements ApplicationContract, HttpKernelIn
     {
         $query = isset($_SERVER['QUERY_STRING']) ? $_SERVER['QUERY_STRING'] : '';
 
-        return '/'.ltrim(str_replace('?'.$query, '', $_SERVER['REQUEST_URI']), '/');
+        return '/'.trim(str_replace('?'.$query, '', $_SERVER['REQUEST_URI']), '/');
     }
 
     /**

--- a/tests/FullApplicationTest.php
+++ b/tests/FullApplicationTest.php
@@ -27,6 +27,46 @@ class ExampleTest extends PHPUnit_Framework_TestCase
     }
 
 
+    public function testRequestWithoutSymfonyClass()
+    {
+        $app = new Application;
+
+        $app->get('/', function () {
+            return response('Hello World');
+        });
+
+        $_SERVER['REQUEST_METHOD'] = 'GET';
+        $_SERVER['REQUEST_URI'] = '/';
+
+        $response = $app->dispatch();
+
+        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertEquals('Hello World', $response->getContent());
+
+        unset($_SERVER['REQUEST_METHOD'], $_SERVER['REQUEST_URI']);
+    }
+
+
+    public function testRequestWithoutSymfonyClassTrailingSlash()
+    {
+        $app = new Application;
+
+        $app->get('/foo', function () {
+            return response('Hello World');
+        });
+
+        $_SERVER['REQUEST_METHOD'] = 'GET';
+        $_SERVER['REQUEST_URI'] = '/foo/';
+
+        $response = $app->dispatch();
+
+        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertEquals('Hello World', $response->getContent());
+
+        unset($_SERVER['REQUEST_METHOD'], $_SERVER['REQUEST_URI']);
+    }
+
+
     public function testRequestWithParameters()
     {
         $app = new Application;


### PR DESCRIPTION
*Fixes #66*

This removes trailing slashes before routing by using `trim` instead of just `ltrim`.
I've also noticed that all existing unit tests used the Symfony Request class so I added two new tests. One that tests a basic request and another (previously failing) test to make sure trailing slashes are stripped correctly.