### PR TITLE
Add query strings to URL generator and fix parameter bug

### DIFF
--- a/src/Routing/UrlGenerator.php
+++ b/src/Routing/UrlGenerator.php
@@ -108,11 +108,17 @@ class UrlGenerator
 
         $uri = $this->app->namedRoutes[$name];
 
-        foreach ($parameters as $key => $value) {
-            $uri = preg_replace('/\{'.$key.'.*?\}/', $value, $uri);
+        $uri = preg_replace_callback('/\{(.*?)(:.*?)?\}/', function ($m) use (&$parameters) {
+            return isset($parameters[$m[1]]) ? array_pull($parameters, $m[1]) : $m[0];
+        }, $uri);
+
+        $uri = $this->to($uri, []);
+
+        if (! empty($parameters)) {
+            $uri .= '?'.http_build_query($parameters);
         }
 
-        return $this->to($uri, []);
+        return $uri;
     }
 
     /**

--- a/tests/FullApplicationTest.php
+++ b/tests/FullApplicationTest.php
@@ -299,6 +299,7 @@ class ExampleTest extends PHPUnit_Framework_TestCase
         $this->assertEquals('http://lumen.laravel.com/something', url('something'));
         $this->assertEquals('http://lumen.laravel.com/foo-bar', route('foo'));
         $this->assertEquals('http://lumen.laravel.com/foo-bar/1/2', route('bar', ['baz' => 1, 'boom' => 2]));
+        $this->assertEquals('http://lumen.laravel.com/foo-bar?baz=1&boom=2', route('foo', ['baz' => 1, 'boom' => 2]));
     }
 
 
@@ -324,6 +325,7 @@ class ExampleTest extends PHPUnit_Framework_TestCase
         $this->assertEquals('http://lumen.laravel.com/foo-bar', route('foo'));
         $this->assertEquals('http://lumen.laravel.com/foo-bar/1/2', route('bar', ['baz' => 1, 'boom' => 2]));
         $this->assertEquals('http://lumen.laravel.com/foo-bar/1/2', route('baz', ['baz' => 1, 'boom' => 2]));
+        $this->assertEquals('http://lumen.laravel.com/foo-bar/{baz:[0-9]+}/{boom:[0-9]+}?ba=1&bo=2', route('baz', ['ba' => 1, 'bo' => 2]));
     }
 
 


### PR DESCRIPTION
*Issue #70*

This PR makes generating an URL for a named route behave more like in Laravel. Parameters that don't exist in the route itself will be appended as GET parameters.

While implementing this I also found a bug in generating URLs for regex routes. Before this PR route parameters where replaced if the parameter only began with the passed name. For example:

    Route: /foo/{bar} - Name: foo

    route('foo', ['b' => 'hello']);

    => /foo/hello

This is fixed now and only one call to `preg_replace_callback` is needed.

Sorry I couldn't split the bugfix and the other stuff in two PRs since it all concerns the same method...