### PR TITLE
Type hint parameter to match the changes in contract

### DIFF
--- a/src/Application.php
+++ b/src/Application.php
@@ -346,7 +346,7 @@ class Application extends Container implements ApplicationContract, HttpKernelIn
      * @param  array   $parameters
      * @return mixed
      */
-    public function make($abstract, $parameters = array())
+    public function make($abstract, array $parameters = array())
     {
         if (array_key_exists($abstract, $this->availableBindings) &&
             ! array_key_exists($this->availableBindings[$abstract], $this->ranServiceBinders)) {


### PR DESCRIPTION
Because of [this change](https://github.com/laravel/framework/commit/27b1d17a420b4556a261c6f7a49115a90edd1018) the parameter has to be type hinted as array for the declarations to match.