### PR TITLE
Get Lumen routing ready for middleware parameters

### DIFF
--- a/src/Application.php
+++ b/src/Application.php
@@ -1291,7 +1291,8 @@ class Application extends Container implements ApplicationContract, HttpKernelIn
         $middleware = is_string($middleware) ? explode('|', $middleware) : (array) $middleware;
 
         return array_map(function ($name) {
-            return $this->routeMiddleware[$name];
+	        list($name, $parameters) = array_pad(explode(':', $name, 2), 2, null);
+	        return array_get($this->routeMiddleware, $name, $name).($parameters ? ':'.$parameters : '');
         }, $middleware);
     }
 

--- a/tests/FullApplicationTest.php
+++ b/tests/FullApplicationTest.php
@@ -68,6 +68,40 @@ class ExampleTest extends PHPUnit_Framework_TestCase
     }
 
 
+    public function testGlobalMiddlewareParameters()
+    {
+        $app = new Application;
+
+        $app->middleware(['LumenTestParameterizedMiddleware:foo,bar']);
+
+        $app->get('/', function () {
+            return response('Hello World');
+        });
+
+        $response = $app->handle(Request::create('/', 'GET'));
+
+        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertEquals('Middleware - foo - bar', $response->getContent());
+    }
+
+
+    public function testRouteMiddlewareParameters()
+    {
+        $app = new Application;
+
+        $app->routeMiddleware(['foo' => 'LumenTestParameterizedMiddleware']);
+
+        $app->get('/', ['middleware' => 'foo:bar,boom', function () {
+            return response('Hello World');
+        }]);
+
+        $response = $app->handle(Request::create('/', 'GET'));
+
+        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertEquals('Middleware - bar - boom', $response->getContent());
+    }
+
+
     public function testGroupRouteMiddleware()
     {
         $app = new Application;
@@ -250,6 +284,12 @@ class LumenTestServiceProvider extends Illuminate\Support\ServiceProvider
 class LumenTestMiddleware {
     public function handle($request, $next) {
           return response('Middleware');
+    }
+}
+
+class LumenTestParameterizedMiddleware {
+    public function handle($request, $next, $parameter1, $parameter2) {
+        return response("Middleware - $parameter1 - $parameter2");
     }
 }
 


### PR DESCRIPTION
Update code for parsing route middleware to ensure that everything will work correctly with middleware parameters in Laravel 5.1. Note that the unit tests will pass as soon as PR #72 is merged.