### PR TITLE
Register Hash facade

### DIFF
--- a/src/Application.php
+++ b/src/Application.php
@@ -768,6 +768,7 @@ class Application extends Container implements ApplicationContract, HttpKernelIn
             class_alias('Illuminate\Support\Facades\DB', 'DB');
             class_alias('Illuminate\Support\Facades\Cache', 'Cache');
             class_alias('Illuminate\Support\Facades\Crypt', 'Crypt');
+            class_alias('Illuminate\Support\Facades\Hash', 'Hash');
             class_alias('Illuminate\Support\Facades\Log', 'Log');
             class_alias('Illuminate\Support\Facades\Mail', 'Mail');
             class_alias('Illuminate\Support\Facades\Queue', 'Queue');


### PR DESCRIPTION
Uncommenting the `$app->withFacades()` call in the bootstrap/app.php file isn't enough to use `Hash` facade.