### PR TITLE
Allow developers to register their own FastRoute dispatcher with the app.

### DIFF
--- a/src/Application.php
+++ b/src/Application.php
@@ -129,6 +129,13 @@ class Application extends Container implements ApplicationContract, HttpKernelIn
     protected $ranServiceBinders = [];
 
     /**
+     * The FastRoute dispatcher.
+     *
+     * @var \FastRoute\Dispatcher
+     */
+    protected $dispatcher;
+
+    /**
      * Create a new Lumen application instance.
      *
      * @param  string|null  $basePath
@@ -1098,11 +1105,22 @@ class Application extends Container implements ApplicationContract, HttpKernelIn
      */
     protected function createDispatcher()
     {
-        return \FastRoute\simpleDispatcher(function ($r) {
+        return $this->dispatcher ?: \FastRoute\simpleDispatcher(function ($r) {
             foreach ($this->routes as $route) {
                 $r->addRoute($route['method'], $route['uri'], $route['action']);
             }
         });
+    }
+
+    /**
+     * Set the FastRoute dispatcher instance.
+     *
+     * @param  \FastRoute\Dispatcher  $dispatcher
+     * @return void
+     */
+    public function setDispatcher(Dispatcher $dispatcher)
+    {
+        $this->dispatcher = $dispatcher;
     }
 
     /**

--- a/tests/FullApplicationTest.php
+++ b/tests/FullApplicationTest.php
@@ -333,6 +333,25 @@ class ExampleTest extends PHPUnit_Framework_TestCase
         $provider = new LumenTestServiceProvider($app);
         $app->register($provider);
     }
+
+
+    public function testUsingCustomDispatcher()
+    {
+        $routes = new FastRoute\RouteCollector(new FastRoute\RouteParser\Std, new FastRoute\DataGenerator\GroupCountBased);
+
+        $routes->addRoute('GET', '/', [function () {
+            return response('Hello World');
+        }]);
+
+        $app = new Application;
+
+        $app->setDispatcher(new FastRoute\Dispatcher\GroupCountBased($routes->getData()));
+
+        $response = $app->handle(Request::create('/', 'GET'));
+
+        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertEquals('Hello World', $response->getContent());
+    }
 }
 
 class LumenTestService {}


### PR DESCRIPTION
Hopefully you can merge this one Taylor. Not a big change by any means. Just allows a little more flexibility with the routing by letting me register a custom dispatcher... You know what for!

Cheers mate.

Signed-off-by: Jason Lewis <jason.lewis1991@gmail.com>