### PR TITLE
add database port to default configuration

### DIFF
--- a/config/database.php
+++ b/config/database.php
@@ -60,6 +60,7 @@ return [
         'mysql' => [
             'driver'    => 'mysql',
             'host'      => env('DB_HOST', 'localhost'),
+            'port'      => env('DB_PORT', 3306),
             'database'  => env('DB_DATABASE', 'forge'),
             'username'  => env('DB_USERNAME', 'forge'),
             'password'  => env('DB_PASSWORD', ''),
@@ -73,6 +74,7 @@ return [
         'pgsql' => [
             'driver'   => 'pgsql',
             'host'     => env('DB_HOST', 'localhost'),
+            'port'     => env('DB_PORT', 5432),
             'database' => env('DB_DATABASE', 'forge'),
             'username' => env('DB_USERNAME', 'forge'),
             'password' => env('DB_PASSWORD', ''),


### PR DESCRIPTION
Hi
I want to use postgresql but with different port. seems like lumen configuration accept port option and just it is not there by default. Also we need to add `DB_PORT` to [.env.example](https://github.com/laravel/lumen/blob/master/.env.example) if you accept this PR.

And I have no idea how sql server works, so I leave it to others.