### PR TITLE
Tweak Application Routing

### DIFF
--- a/src/Application.php
+++ b/src/Application.php
@@ -1086,13 +1086,15 @@ class Application extends Container implements ApplicationContract, HttpKernelIn
         }
 
         try {
-            if (isset($this->routes[$method.$pathInfo])) {
-                return $this->handleFoundRoute([true, $this->routes[$method.$pathInfo]['action'], []]);
-            }
+            return $this->sendThroughPipeline($this->middleware, function () use ($method, $pathInfo) {
+                if (isset($this->routes[$method.$pathInfo])) {
+                    return $this->handleFoundRoute([true, $this->routes[$method.$pathInfo]['action'], []]);
+                }
 
-            return $this->handleDispatcherResponse(
-                $this->createDispatcher()->dispatch($method, $pathInfo)
-            );
+                return $this->handleDispatcherResponse(
+                    $this->createDispatcher()->dispatch($method, $pathInfo)
+                );
+            });
         } catch (Exception $e) {
             return $this->sendExceptionToHandler($e);
         }
@@ -1144,7 +1146,7 @@ class Application extends Container implements ApplicationContract, HttpKernelIn
     }
 
     /**
-     * Handle a route that was found by the dispatcher.
+     * Handle a route found by the dispatcher.
      *
      * @param  array  $routeInfo
      * @return mixed
@@ -1153,24 +1155,6 @@ class Application extends Container implements ApplicationContract, HttpKernelIn
     {
         $this->currentRoute = $routeInfo;
 
-        // Pipe through global middleware...
-        if (count($this->middleware) > 0) {
-            return $this->prepareResponse($this->sendThroughPipeline($this->middleware, function () use ($routeInfo) {
-                return $this->prepareResponse($this->handleArrayBasedFoundRoute($routeInfo));
-            }));
-        }
-
-        return $this->handleArrayBasedFoundRoute($routeInfo);
-    }
-
-    /**
-     * Handle an array based route that was found by the dispatcher.
-     *
-     * @param  array  $routeInfo
-     * @return mixed
-     */
-    protected function handleArrayBasedFoundRoute($routeInfo)
-    {
         $action = $routeInfo[1];
 
         // Pipe through route middleware...
@@ -1178,7 +1162,7 @@ class Application extends Container implements ApplicationContract, HttpKernelIn
             $middleware = $this->gatherMiddlewareClassNames($action['middleware']);
 
             return $this->prepareResponse($this->sendThroughPipeline($middleware, function () use ($routeInfo) {
-                return $this->prepareResponse($this->callActionOnArrayBasedRoute($routeInfo));
+                return $this->callActionOnArrayBasedRoute($routeInfo);
             }));
         }
 
@@ -1324,10 +1308,14 @@ class Application extends Container implements ApplicationContract, HttpKernelIn
      */
     protected function sendThroughPipeline(array $middleware, Closure $then)
     {
-        return (new Pipeline($this))
-            ->send($this->make('request'))
-            ->through($middleware)
-            ->then($then);
+        if (count($middleware) > 0) {
+            return (new Pipeline($this))
+                ->send($this->make('request'))
+                ->through($middleware)
+                ->then($then);
+        }
+
+        return $then();
     }
 
     /**


### PR DESCRIPTION
This is in response to #87.

The idea is that the routing behave in a similar manner to that of L5. Currently, Lumen will look for a route first before it tries to pipe the request through the middlewares.

Laravel 5 will pipe the request through the middlewares first and then find and dispatch the route.

Obviously they both do routing a little differently, however, I think this difference is a bad one and can lead to some unexpected results. As it stands a global middleware in L5 will always be run even if the route does not exist. That's expected behaviour to me. In Lumen, the global middleware will never run if the route does not exist.

This PR fixes that by piping the request through the middleware first.

### Performance

This was going to be my biggest concern, however, it seems the change doesn't affect it at all. Firstly, the request is only piped through the middleware *IF* their are middleware. So it doesn't new up a pipline for no reason. When testing that seemed to be the biggest drain on the amount of requests I could generate per second.

Here are my benchmark results (`ab -t 10 -c 10 http://lumen.app/`):

**Current 5.0 Branch**

Request No. | Requests Per Second
----------------- | --------------------------------
1                   | 222.44
2                   | 225.09
3                   | 229.46
4                   | 224.21
5                   | 224.78
**Avgerage**         | 225.2

**PR Branch**

Request No. | Requests Per Second
----------------- | --------------------------------
1                   | 218.15
2                   | 230.03
3                   | 229.37
4                   | 228.80
5                   | 225.64 
**Avgerage**         | 226.4

(I know the numbers are low... not a lot of memory here!)

The fact is the benchmarks didn't really change at all with the changes I've made.

Signed-off-by: Jason Lewis <jason.lewis1991@gmail.com>