### PR TITLE
getLocale function added

### DIFF
--- a/src/Application.php
+++ b/src/Application.php
@@ -1500,6 +1500,14 @@ class Application extends Container implements ApplicationContract, HttpKernelIn
     }
 
     /**
+     * @return mixed
+     */
+    public function getLocale()
+    {
+        return $this['translator']->getLocale();
+    }
+
+    /**
      * Set the cached routes.
      *
      * @param  array  $routes


### PR DESCRIPTION
Some packages uses this function in Laravel, if you want to include them
into your Lumen app, they will crash. This fix solves that problem.