### PR TITLE
Resolved a problem where response()->download() was returning 0 bytes.

### DIFF
--- a/src/Application.php
+++ b/src/Application.php
@@ -1331,6 +1331,8 @@ class Application extends Container implements ApplicationContract, HttpKernelIn
             $response = new Response($response);
         }
 
+        $response->prepare(Request::capture());
+
         return $response;
     }
 


### PR DESCRIPTION
I ran into the same issue as https://github.com/laravel/lumen-framework/issues/74 where the content body was returning nothing. After further debugging I found out that in the Symfony HttpFoundation was returning a maxlen of 0 everytime. The maxlen variable was never being set since the prepare() method was never called. After evoking the prepare() method in BinaryFileResponse it set the maxlen properly and returned the correct size of the file. I don't know if this is the proper way of doing this, but it works.

Thanks!