### PR TITLE
Unused Method

### DIFF
--- a/src/Application.php
+++ b/src/Application.php
@@ -186,16 +186,6 @@ class Application extends Container implements ApplicationContract, HttpKernelIn
     }
 
     /**
-     * Determine if the application is currently down for maintenance.
-     *
-     * @return bool
-     */
-    public function isDownForMaintenance()
-    {
-        return false;
-    }
-
-    /**
      * Register all of the configured providers.
      *
      * @return void


### PR DESCRIPTION
I asked if we can get the nice artisan command `up` and `down`.
https://github.com/laravel/lumen-framework/issues/79

Since the answer was no, we don't need the `isDownForMaintenance()` method. I checked and it is not called anywhere.