### PR TITLE
Checked if response is an instance of BinaryFileResponse and returned a prepared response

### DIFF
--- a/src/Application.php
+++ b/src/Application.php
@@ -1331,7 +1331,9 @@ class Application extends Container implements ApplicationContract, HttpKernelIn
             $response = new Response($response);
         }
 
-        $response->prepare(Request::capture());
+        if ($response instanceof BinaryFileResponse) {
+            $response = $response->prepare(Request::capture());
+        }
 
         return $response;
     }

--- a/src/Application.php
+++ b/src/Application.php
@@ -1331,6 +1331,8 @@ class Application extends Container implements ApplicationContract, HttpKernelIn
             $response = new Response($response);
         }
 
+        $response->prepare(Request::capture());
+
         return $response;
     }
 


### PR DESCRIPTION
Created a new PR as requested by Taylor to check if the response is a BinaryFileResponse. If the response is, then it is prepared before sending the download to the user. This prevents less overhead with "normal" requests while fixing an "issue" with the download() functionality. The PR is in reference to this PR https://github.com/laravel/lumen-framework/pull/102 *AND* this issue https://github.com/laravel/lumen-framework/issues/74

Thanks!