### PR TITLE
Add custom attributes param for Controller Validation

### DIFF
--- a/src/Routing/ValidatesRequests.php
+++ b/src/Routing/ValidatesRequests.php
@@ -14,11 +14,12 @@ trait ValidatesRequests
      * @param  \Illuminate\Http\Request  $request
      * @param  array  $rules
      * @param  array  $messages
+     * @param  array  $customAttributes
      * @return void
      */
-    public function validate(Request $request, array $rules, array $messages = array())
+    public function validate(Request $request, array $rules, array $messages = array(), array $customAttributes = array())
     {
-        $validator = $this->getValidationFactory()->make($request->all(), $rules, $messages);
+        $validator = $this->getValidationFactory()->make($request->all(), $rules, $messages, $customAttributes);
 
         if ($validator->fails()) {
             $this->throwValidationException($request, $validator);


### PR DESCRIPTION
`Validator::make()` has the 4th param `$customAttributes` and it's so useful.
In case of Controller Validation, `$this->validate()` doesn't work with it.
The simplest solution is just to add `$customAttributes` param to `ValidatesRequests::validate()`.