### PR TITLE
Added missing dependency to SuperClosure

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -43,7 +43,8 @@
         "symfony/http-kernel": "2.6.*",
         "symfony/http-foundation": "2.6.*",
         "symfony/security-core": "2.6.*",
-        "symfony/var-dumper": "2.6.*"
+        "symfony/var-dumper": "2.6.*",
+        "jeremeamia/superclosure": "~2.0"
     },
     "require-dev": {
         "phpunit/phpunit": "~4.0",


### PR DESCRIPTION
During `Mail::queue()` I've got an exception:

> Fatal error: Class 'SuperClosure\Serializer' not found in /var/www/api/vendor/illuminate/mail/Mailer.php on line 243

It looks like there's a missing dependency to `jeremeamia/superclosure`.