### PR TITLE
Move the dispatching ahead of Middleware.

### DIFF
--- a/src/Application.php
+++ b/src/Application.php
@@ -1087,21 +1087,19 @@ class Application extends Container implements ApplicationContract, HttpKernelIn
             $pathInfo = $this->getPathInfo();
         }
 
-        if(isset($this->routes[$method.$pathInfo])){
+        if ($withoutParam = isset($this->routes[$method.$pathInfo])) {
             $this->currentRoute = [true, $this->routes[$method.$pathInfo]['action'], []];
-        }else{
+        } else {
             $this->currentRoute = $this->createDispatcher()->dispatch($method, $pathInfo);
         }
 
         try {
-            return $this->sendThroughPipeline($this->middleware, function () use ($method, $pathInfo) {
-                if (isset($this->routes[$method.$pathInfo])) {
+            return $this->sendThroughPipeline($this->middleware, function () use ($withoutParam) {
+                if ($withoutParam) {
                     return $this->handleFoundRoute($this->currentRoute);
                 }
 
-                return $this->handleDispatcherResponse(
-                    $this->currentRoute
-                );
+                return $this->handleDispatcherResponse($this->currentRoute);
             });
         } catch (Exception $e) {
             return $this->sendExceptionToHandler($e);
@@ -1520,6 +1518,8 @@ class Application extends Container implements ApplicationContract, HttpKernelIn
     }
 
     /**
+     * Get the matched current route.
+     * 
      * @return array
      */
     public function getCurrentRoute()

--- a/src/Application.php
+++ b/src/Application.php
@@ -1087,14 +1087,20 @@ class Application extends Container implements ApplicationContract, HttpKernelIn
             $pathInfo = $this->getPathInfo();
         }
 
+        if(isset($this->routes[$method.$pathInfo])){
+            $this->currentRoute = [true, $this->routes[$method.$pathInfo]['action'], []];
+        }else{
+            $this->currentRoute = $this->createDispatcher()->dispatch($method, $pathInfo);
+        }
+
         try {
             return $this->sendThroughPipeline($this->middleware, function () use ($method, $pathInfo) {
                 if (isset($this->routes[$method.$pathInfo])) {
-                    return $this->handleFoundRoute([true, $this->routes[$method.$pathInfo]['action'], []]);
+                    return $this->handleFoundRoute($this->currentRoute);
                 }
 
                 return $this->handleDispatcherResponse(
-                    $this->createDispatcher()->dispatch($method, $pathInfo)
+                    $this->currentRoute
                 );
             });
         } catch (Exception $e) {
@@ -1511,6 +1517,14 @@ class Application extends Container implements ApplicationContract, HttpKernelIn
     public function setRoutes(array $routes)
     {
         $this->routes = $routes;
+    }
+
+    /**
+     * @return array
+     */
+    public function getCurrentRoute()
+    {
+        return $this->currentRoute;
     }
 
     /**


### PR DESCRIPTION
Move the dispatching ahead of Middleware, so that the current route information is available in case of some authentication. 
I was writing a role based access control middleware and found it is impossible to get current route info before controller@action is invoked. [My problem](http://stackoverflow.com/questions/30577949/can-i-get-current-route-information-in-middleware-with-lumen)