### PR TITLE
Added access to route definition from request instance

### DIFF
--- a/src/Application.php
+++ b/src/Application.php
@@ -1159,6 +1159,12 @@ class Application extends Container implements ApplicationContract, HttpKernelIn
 
         $action = $routeInfo[1];
 
+        // set route info as route resolve, so $request->route() will return it
+        // and you can access route info (name, uses, ...) in middleware for example as $request->route()[1]['uses']
+        $this->make('Illuminate\Http\Request')->setRouteResolver(function() use ($routeInfo) {
+            return $routeInfo;
+        });
+
         // Pipe through route middleware...
         if (isset($action['middleware'])) {
             $middleware = $this->gatherMiddlewareClassNames($action['middleware']);


### PR DESCRIPTION
This pull request solves problem when you want to access route definition in a middleware but `$request->route()` always returns `null`. Now it returns associative array with route definition (action) under key `1`.

```php
$request->route(); // array(..., 1 => ['middleware' => ....]...)
```