### PR TITLE
Return response from welcome

### DIFF
--- a/src/Application.php
+++ b/src/Application.php
@@ -1592,7 +1592,7 @@ class Application extends Container implements ApplicationContract, HttpKernelIn
      */
     public function welcome()
     {
-        return "<html>
+        return new Response("<html>
             <head>
                 <title>Lumen</title>
 
@@ -1639,6 +1639,6 @@ class Application extends Container implements ApplicationContract, HttpKernelIn
                 </div>
             </body>
         </html>
-        ";
+        ");
     }
 }

--- a/tests/FullApplicationTest.php
+++ b/tests/FullApplicationTest.php
@@ -367,6 +367,13 @@ class ExampleTest extends PHPUnit_Framework_TestCase
         $provider = new LumenTestServiceProvider($app);
         $app->register($provider);
     }
+
+
+    public function testWelcomeReturnsResponse()
+    {
+        $app = new Application;
+        $this->assertInstanceOf('Illuminate\Http\Response', $app->welcome());
+    }
 }
 
 class LumenTestService {}


### PR DESCRIPTION
VerifyCsrfToken breaks at [line 75](https://github.com/laravel/lumen-framework/blob/master/src/Http/Middleware/VerifyCsrfToken.php#L75) because it gets a string instead of response object