### PR TITLE
Correct $uri when ['prefix' => ''] and ['prefix' => '/'].

### DIFF
--- a/src/Application.php
+++ b/src/Application.php
@@ -911,15 +911,15 @@ class Application extends Container implements ApplicationContract, HttpKernelIn
     {
         $action = $this->parseAction($action);
 
-        $uri = $uri === '/' ? $uri : '/'.trim($uri, '/');
-
         if (isset($this->groupAttributes)) {
             if (isset($this->groupAttributes['prefix'])) {
-                $uri = rtrim('/'.trim($this->groupAttributes['prefix'], '/').$uri, '/');
+                $uri = trim($this->groupAttributes['prefix'], '/').'/'.trim($uri, '/');
             }
 
             $action = $this->mergeGroupAttributes($action);
         }
+
+        $uri = '/'.trim($uri, '/');
 
         if (isset($action['as'])) {
             $this->namedRoutes[$action['as']] = $uri;


### PR DESCRIPTION
Correct routing uri when
- ['prefix' => '']
- ['prefix' => '/']

before not found because double slash start uri generated.
ex) '//path/to'
