### PR TITLE
deferred call to boot() method of service providers + test

### DIFF
--- a/src/Application.php
+++ b/src/Application.php
@@ -375,6 +375,8 @@ class Application extends Container implements ApplicationContract, HttpKernelIn
 
     /**
      * Boots service providers
+     *
+     * @return void
      */
     protected function bootServiceProviders()
     {
@@ -382,7 +384,6 @@ class Application extends Container implements ApplicationContract, HttpKernelIn
             $provider->boot();
         }
     }
-
 
     /**
      * Register container bindings for the application.

--- a/tests/FullApplicationTest.php
+++ b/tests/FullApplicationTest.php
@@ -337,6 +337,19 @@ class ExampleTest extends PHPUnit_Framework_TestCase
     }
 
 
+    public function testBootRegisteredServiceProvider()
+    {
+        $app = new Application;
+        $provider = new LumenTestServiceProvider($app);
+        $app->register($provider);
+        $this->assertFalse($provider->bootCalled);
+
+        $app->handle(Request::create('/', 'GET'));
+
+        $this->assertTrue($provider->bootCalled);
+    }
+
+
     public function testUsingCustomDispatcher()
     {
         $routes = new FastRoute\RouteCollector(new FastRoute\RouteParser\Std, new FastRoute\DataGenerator\GroupCountBased);
@@ -360,7 +373,12 @@ class LumenTestService {}
 
 class LumenTestServiceProvider extends Illuminate\Support\ServiceProvider
 {
+
+    public $bootCalled = false;
+
     public function register() {}
+
+    public function boot() { $this->bootCalled = true; }
 }
 
 class LumenTestMiddleware {


### PR DESCRIPTION
Call of a `boot()` method on a service provider is deferred until the `dispatch()` is called. 

Fixes #126 