### PR TITLE
Facades don't work with Testing\Testcase - 'Class config does not exist'

### DIFF
--- a/src/Testing/ApplicationTrait.php
+++ b/src/Testing/ApplicationTrait.php
@@ -2,6 +2,7 @@
 
 use Illuminate\Http\Request;
 use Illuminate\Contracts\Auth\Authenticatable as UserContract;
+use Illuminate\Support\Facades\Facade;
 
 trait ApplicationTrait
 {
@@ -37,6 +38,7 @@ trait ApplicationTrait
         putenv('APP_ENV=testing');
 
         $this->app = $this->createApplication();
+        Facade::clearResolvedInstances();
     }
 
     /**

--- a/tests/TestingTest.php
+++ b/tests/TestingTest.php
@@ -1,0 +1,33 @@
+<?php
+
+use Mockery as m;
+use Illuminate\Http\Request;
+use Laravel\Lumen\Application;
+
+class TestingTest extends \Laravel\Lumen\Testing\TestCase
+{
+    public function createApplication()
+    {
+        return new Application;
+    }
+
+    //
+    // These two tests works in pair to show a problem with missing call to "Facade::clearResolvedInstances()"
+    // when using Lumen Testing TestCase. It recreates app instance on each test, but also needs to clear the
+    // facade instances created with the previous app instance.
+    //
+    public function testFirstMethodUsingFacades()
+    {
+        $this->app->withFacades();
+        Illuminate\Support\Facades\Auth::user();
+    }
+    public function testSecondMethodUsingFacades()
+    {
+        $this->app->withFacades();
+        Illuminate\Support\Facades\Auth::user();
+
+    }
+}
+
+
+

--- a/tests/TestingTest.php
+++ b/tests/TestingTest.php
@@ -6,7 +6,6 @@ use Illuminate\Support\Facades\Auth;
 
 class TestingTest extends TestCase
 {
-
     public function createApplication()
     {
         return new Application;
@@ -23,12 +22,10 @@ class TestingTest extends TestCase
         $this->app->withFacades();
         Auth::user();
     }
+
     public function testSecondMethodUsingFacades()
     {
         $this->app->withFacades();
         Auth::user();
     }
 }
-
-
-

--- a/tests/TestingTest.php
+++ b/tests/TestingTest.php
@@ -1,31 +1,32 @@
 <?php
 
-use Mockery as m;
-use Illuminate\Http\Request;
 use Laravel\Lumen\Application;
+use Laravel\Lumen\Testing\TestCase;
+use Illuminate\Support\Facades\Auth;
 
-class TestingTest extends \Laravel\Lumen\Testing\TestCase
+class TestingTest extends TestCase
 {
+
     public function createApplication()
     {
         return new Application;
     }
 
-    //
-    // These two tests works in pair to show a problem with missing call to "Facade::clearResolvedInstances()"
-    // when using Lumen Testing TestCase. It recreates app instance on each test, but also needs to clear the
-    // facade instances created with the previous app instance.
-    //
+    /**
+     * The two tests testFirstMethodUsingFacades and testSecondMethodUsingFacades works in pair to show a problem
+     * with missing call to "Facade::clearResolvedInstances()" when using Lumen Testing TestCase.
+     * It recreates app instance on each test, but also needs to clear the facade instances created with the
+     * previous app instance.
+     */
     public function testFirstMethodUsingFacades()
     {
         $this->app->withFacades();
-        Illuminate\Support\Facades\Auth::user();
+        Auth::user();
     }
     public function testSecondMethodUsingFacades()
     {
         $this->app->withFacades();
-        Illuminate\Support\Facades\Auth::user();
-
+        Auth::user();
     }
 }
 


### PR DESCRIPTION
Fixes problem with Laravel\Lumen\Testing\TestCase not properly clearing Facade instances when refreshing the app instance.

There are several other issues referring to this problem, I think: #108, #125, laravel/framework#8547,  laravel/framework#7017