### PR TITLE
Fix a error using the 5.1.*@dev

### DIFF
--- a/src/Application.php
+++ b/src/Application.php
@@ -1513,6 +1513,26 @@ class Application extends Container implements ApplicationContract, HttpKernelIn
     {
         $this->routes = $routes;
     }
+    
+    /**
+     * Get the path to the cached "compiled.php" file.
+     *
+     * @return string
+     */
+    public function getCachedCompilePath()
+    {
+        return $this->basePath().'/bootstrap/cache/compiled.php';
+    }
+
+    /**
+     * Get the path to the cached services.json file.
+     *
+     * @return string
+     */
+    public function getCachedServicesPath()
+    {
+        return $this->basePath().'/bootstrap/cache/services.json';
+    }
 
     /**
      * Register the core container aliases.


### PR DESCRIPTION
Fix a error using the 5.1.*@dev version missing methods from interface Illuminate\Contracts\Foundation\Application

    public function getCachedCompilePath()
    public function getCachedServicesPath()