### PR TITLE
Add container alias for Illuminate\Contracts\Config\Repository

### DIFF
--- a/src/Application.php
+++ b/src/Application.php
@@ -1563,6 +1563,7 @@ class Application extends Container implements ApplicationContract, HttpKernelIn
             'Illuminate\Contracts\Auth\PasswordBroker' => 'auth.password',
             'Illuminate\Contracts\Cache\Factory' => 'cache',
             'Illuminate\Contracts\Cache\Repository' => 'cache.store',
+            'Illuminate\Contracts\Config\Repository' => 'config',
             'Illuminate\Container\Container' => 'app',
             'Illuminate\Contracts\Container\Container' => 'app',
             'Illuminate\Contracts\Cookie\Factory' => 'cookie',


### PR DESCRIPTION
I'm not sure if this was left out intentionally or not but as it stands I can't inject an instance of the config repository, so here we go. :+1: