### PR TITLE
Fix for fatal error with renamed DispatchesCommands trait

### DIFF
--- a/src/Routing/Controller.php
+++ b/src/Routing/Controller.php
@@ -4,7 +4,7 @@ use Illuminate\Http\Request;
 
 abstract class Controller
 {
-    use DispatchesCommands, ValidatesRequests;
+    use DispatchesJobs, ValidatesRequests;
 
     /**
      * The middleware defined on the controller.


### PR DESCRIPTION
PHP Fatal error:  Trait 'Laravel\Lumen\Routing\DispatchesCommands' not found