### PR TITLE
Assert response is JSON even when data is passed

### DIFF
--- a/src/Testing/CrawlerTrait.php
+++ b/src/Testing/CrawlerTrait.php
@@ -287,15 +287,11 @@ trait CrawlerTrait
      */
     public function seeJson(array $data = null)
     {
-        if (is_null($data)) {
-            $this->assertJson(
-                $this->response->getContent(), "Failed asserting that JSON returned [{$this->currentUri}]."
-            );
+        $this->assertJson(
+            $this->response->getContent(), "Failed asserting that JSON returned [{$this->currentUri}]."
+        );
 
-            return $this;
-        }
-
-        return $this->seeJsonContains($data);
+        return is_null($data) ? $this : $this->seeJsonContains($data);
     }
 
     /**


### PR DESCRIPTION
Not testing the response when we have data, means that an invalid JSON response results a confusing error:

```
1) AccountTest::testBasicCreate
ErrorException: Invalid argument supplied for foreach()

<project-dir>/vendor/illuminate/support/helpers.php:534
<project-dir>/vendor/laravel/lumen-framework/src/Testing/CrawlerTrait.php:311
<project-dir>/vendor/laravel/lumen-framework/src/Testing/CrawlerTrait.php:298
<project-dir>/xero_api/tests/endpoints/AccountTest.php:66
<project-dir>/xero_api/tests/endpoints/AccountTest.php:16
<project-dir>/phpunit/phpunit/src/TextUI/Command.php:151
<project-dir>/phpunit/phpunit/src/TextUI/Command.php:103
```

After this fix an invalid JSON response results in:

```
Failed asserting that JSON returned [http://localhost/account/1].
Failed asserting that '<!DOCTYPE html>\n<html>\n    <h.../html>' is valid JSON (Syntax error, malformed JSON).
```