### PR TITLE
set correct basePath when running cli-server

### DIFF
--- a/src/Application.php
+++ b/src/Application.php
@@ -1412,7 +1412,7 @@ class Application extends Container implements ApplicationContract, HttpKernelIn
             return $this->basePath.($path ? '/'.$path : $path);
         }
 
-        if ($this->runningInConsole() || php_sapi_name() === 'cli-server') {
+        if ($this->runningInConsole()) {
             $this->basePath = getcwd();
         } else {
             $this->basePath = realpath(getcwd().'/../');


### PR DESCRIPTION
This PR undoes https://github.com/laravel/lumen-framework/pull/32 and is to ensure the default `Application::basePath` is set to the application root dir.

By using the  `lumen new` command to instantiate a new project, the directory structure nests index.php under `root/public` and therefore `getcwd()` returns one level too deep for the app to access the `root/storage` dir.

For more info on the issue: https://laracasts.com/discuss/channels/general-discussion/why-the-app-basepath-is-the-public-folder