### PR TITLE
Remove Mockery from the Laravel\Lumen\Testing namespace

### DIFF
--- a/src/Testing/TestCase.php
+++ b/src/Testing/TestCase.php
@@ -63,7 +63,7 @@ abstract class TestCase extends PHPUnit_Framework_TestCase
     public function tearDown()
     {
         if (class_exists('Mockery')) {
-            Mockery::close();
+            \Mockery::close();
         }
 
         if ($this->app) {


### PR DESCRIPTION
I was getting the error message:

```
PHP Fatal error:  Class 'Laravel\Lumen\Testing\Mockery' not found in .../vendor/laravel/lumen-framework/src/Testing/TestCase.php on line 66
```

This seems to fix that.