### PR TITLE
[phpunit]: delete unused syntaxCheck parameter

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -9,7 +9,6 @@
          processIsolation="false"
          stopOnError="false"
          stopOnFailure="false"
-         syntaxCheck="true"
          verbose="true"
 >
     <testsuites>


### PR DESCRIPTION
Hi,

The `syntaxCheck` parameter do not exist. So we can delete it.

https://phpunit.de/manual/current/en/appendixes.configuration.html

Regards