### PR TITLE
[5.1] Fixes #165

### DIFF
--- a/src/Application.php
+++ b/src/Application.php
@@ -1538,6 +1538,16 @@ class Application extends Container implements ApplicationContract, HttpKernelIn
     }
 
     /**
+     * Get the application namespace.
+     *
+     * @return string
+     */
+    public function getNamespace()
+    {
+        return 'App\\';
+    }
+
+    /**
      * Set the cached routes.
      *
      * @param  array  $routes


### PR DESCRIPTION
Closes #165

We can hardcode the namespace because there is no `app:name` command in Lumen, right?