### PR TITLE
[5.1] Fix Cache Store Resolution

### DIFF
--- a/src/Application.php
+++ b/src/Application.php
@@ -445,6 +445,10 @@ class Application extends Container implements ApplicationContract, HttpKernelIn
         $this->singleton('cache', function () {
             return $this->loadComponent('cache', 'Illuminate\Cache\CacheServiceProvider');
         });
+        
+        $this->singleton('cache.store', function () {
+            return $this->loadComponent('cache', 'Illuminate\Cache\CacheServiceProvider', 'cache.store');
+        });
     }
 
     /**


### PR DESCRIPTION
Add 'cache.store' binding in Application:registerCacheBindings() - to resolve ReflectionException.

---
Closes #161.