### PR TITLE
fix: take withoutMiddlewear() method call in CrawlerTrait to account …

### DIFF
--- a/src/Application.php
+++ b/src/Application.php
@@ -1357,7 +1357,10 @@ class Application extends Container implements ApplicationContract, HttpKernelIn
      */
     protected function sendThroughPipeline(array $middleware, Closure $then)
     {
-        if (count($middleware) > 0) {
+        $shouldSkipMiddleware = $this->app->bound('middleware.disable') &&
+                                        $this->app->make('middleware.disable') === true;
+
+        if (count($middleware) > 0 and $shouldSkipMiddleware === false) {
             return (new Pipeline($this))
                 ->send($this->make('request'))
                 ->through($middleware)

--- a/src/Application.php
+++ b/src/Application.php
@@ -1360,7 +1360,7 @@ class Application extends Container implements ApplicationContract, HttpKernelIn
         $shouldSkipMiddleware = $this->bound('middleware.disable') &&
                                         $this->make('middleware.disable') === true;
 
-        if (count($middleware) > 0 and $shouldSkipMiddleware === false) {
+        if (count($middleware) > 0 && $shouldSkipMiddleware === false) {
             return (new Pipeline($this))
                 ->send($this->make('request'))
                 ->through($middleware)

--- a/src/Application.php
+++ b/src/Application.php
@@ -1357,8 +1357,8 @@ class Application extends Container implements ApplicationContract, HttpKernelIn
      */
     protected function sendThroughPipeline(array $middleware, Closure $then)
     {
-        $shouldSkipMiddleware = $this->app->bound('middleware.disable') &&
-                                        $this->app->make('middleware.disable') === true;
+        $shouldSkipMiddleware = $this->bound('middleware.disable') &&
+                                        $this->make('middleware.disable') === true;
 
         if (count($middleware) > 0 and $shouldSkipMiddleware === false) {
             return (new Pipeline($this))

--- a/tests/FullApplicationTest.php
+++ b/tests/FullApplicationTest.php
@@ -221,6 +221,23 @@ class ExampleTest extends PHPUnit_Framework_TestCase
         $this->assertEquals('Hello World', $response->getContent());
     }
 
+    public function testWithMiddlewareDisabled()
+    {
+        $app = new Application;
+
+        $app->middleware(['LumenTestMiddleware']);
+        $app->instance('middleware.disable', true);
+        
+        $app->get('/', function () {
+            return response('Hello World');
+        });
+
+        $response = $app->handle(Request::create('/', 'GET'));
+
+        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertEquals('Hello World', $response->getContent());
+    }
+
 
     public function testGroupPrefixRoutes()
     {


### PR DESCRIPTION
`Laravel\Lumen\Testing\CrawlerTrait` implements `withoutMiddleware` method. However when testing application doesn't skip middleware as expected.