### PR TITLE
SESSION_COOKIE_NAME env option to set a custom name of the cookie for session

### DIFF
--- a/config/session.php
+++ b/config/session.php
@@ -109,7 +109,7 @@ return [
     |
     */
 
-    'cookie' => 'laravel_session',
+    'cookie' => env('SESSION_DRIVER', 'laravel_session'),
 
     /*
     |--------------------------------------------------------------------------

--- a/config/session.php
+++ b/config/session.php
@@ -109,7 +109,7 @@ return [
     |
     */
 
-    'cookie' => env('SESSION_DRIVER', 'laravel_session'),
+    'cookie' => env('SESSION_COOKIE_NAME', 'laravel_session'),
 
     /*
     |--------------------------------------------------------------------------


### PR DESCRIPTION
Add the option to set a custom name of the cookie for session in the environment file configuration, by default accept the name of 'laravel_session'

'cookie' => env('SESSION_COOKIE_NAME', 'laravel_session')

* Fix the name of env variable in #180 