### PR TITLE
Made Application::getPathInfo() protected

### DIFF
--- a/src/Application.php
+++ b/src/Application.php
@@ -1426,7 +1426,7 @@ class Application extends Container implements ApplicationContract, HttpKernelIn
      *
      * @return string
      */
-    public function getPathInfo()
+    protected function getPathInfo()
     {
         $query = isset($_SERVER['QUERY_STRING']) ? $_SERVER['QUERY_STRING'] : '';
 


### PR DESCRIPTION
Implementation of the change suggested and still under discussion here:

https://github.com/laravel/lumen-framework/issues/190
https://github.com/laravel/lumen-framework/issues/186

As people may have built against this method being public - I'm assuming we will have to wait until the next major version before implementing such a change.