### PR TITLE
Update session.php to allow naming of session cookie

### DIFF
--- a/config/session.php
+++ b/config/session.php
@@ -109,7 +109,7 @@ return [
     |
     */
 
-    'cookie' => 'laravel_session',
+    'cookie' => env('COOKIE_NAME','laravel_session'),
 
     /*
     |--------------------------------------------------------------------------


### PR DESCRIPTION
This allows the framework to actually change the session cookie name, as the comments directly above it allude to.