### PR TITLE
Curly brackets in route regex

### DIFF
--- a/src/Routing/UrlGenerator.php
+++ b/src/Routing/UrlGenerator.php
@@ -200,7 +200,7 @@ class UrlGenerator
         
         $parameters = $this->formatParametersForUrl($parameters);
 
-        $uri = preg_replace_callback('/\{(.*?)(:.*?)?\}/', function ($m) use (&$parameters) {
+        $uri = preg_replace_callback('/\{(.*?)(:.*?)?(\{[0-9,]+\})?\}/', function ($m) use (&$parameters) {
             return isset($parameters[$m[1]]) ? array_pull($parameters, $m[1]) : $m[0];
         }, $uri);
 

--- a/tests/FullApplicationTest.php
+++ b/tests/FullApplicationTest.php
@@ -372,11 +372,16 @@ class ExampleTest extends PHPUnit_Framework_TestCase
             //
         }]);
 
+        $app->get('/foo-bar/{baz:[0-9]{2,5}}', ['as' => 'boom', function() {
+            //
+        }]);
+
         $this->assertEquals('http://lumen.laravel.com/something', url('something'));
         $this->assertEquals('http://lumen.laravel.com/foo-bar', route('foo'));
         $this->assertEquals('http://lumen.laravel.com/foo-bar/1/2', route('bar', ['baz' => 1, 'boom' => 2]));
         $this->assertEquals('http://lumen.laravel.com/foo-bar/1/2', route('baz', ['baz' => 1, 'boom' => 2]));
         $this->assertEquals('http://lumen.laravel.com/foo-bar/{baz:[0-9]+}/{boom:[0-9]+}?ba=1&bo=2', route('baz', ['ba' => 1, 'bo' => 2]));
+        $this->assertEquals('http://lumen.laravel.com/foo-bar/5', route('boom', ['baz' => 5]));
     }
 
 


### PR DESCRIPTION
Little fix that will get rid of trailing curly bracket in case of using regex to check parameter length.

Without that generating route from something like `/test/{param:[0-9]{5}}` will lead to `/test/5}` (as you can check by running added test without fixed regex).