### PR TITLE
repair custom attributes not working

### DIFF
--- a/src/Routing/ValidatesRequests.php
+++ b/src/Routing/ValidatesRequests.php
@@ -20,7 +20,8 @@ trait ValidatesRequests
     public function validate(Request $request, array $rules, array $messages = [], array $customAttributes = [])
     {
         $validator = $this->getValidationFactory()->make($request->all(), $rules, $messages, $customAttributes);
-         $validator->setAttributeNames($customAttributes);
+        $validator->setAttributeNames($customAttributes);
+        
         if ($validator->fails()) {
             $this->throwValidationException($request, $validator);
         }

--- a/src/Routing/ValidatesRequests.php
+++ b/src/Routing/ValidatesRequests.php
@@ -20,7 +20,7 @@ trait ValidatesRequests
     public function validate(Request $request, array $rules, array $messages = [], array $customAttributes = [])
     {
         $validator = $this->getValidationFactory()->make($request->all(), $rules, $messages, $customAttributes);
-
+         $validator->setAttributeNames($customAttributes);
         if ($validator->fails()) {
             $this->throwValidationException($request, $validator);
         }


### PR DESCRIPTION
```php
$attributes = [
            'name' => '姓名',
            'mobile' => '手机',
            'qq' => 'QQ号码',
            'company_name' => '公司名称',
            'company_tel' => '公司电话'
        ];
$this->validate($this->request, $rules, [], $attributes);
```
not working