### PR TITLE
Don't make Content-Type header with the "HTTP_" superglobal prefix

### DIFF
--- a/src/Testing/CrawlerTrait.php
+++ b/src/Testing/CrawlerTrait.php
@@ -145,7 +145,9 @@ trait CrawlerTrait
         $server = [];
 
         foreach ($headers as $name => $value) {
-            if (! starts_with($name, 'HTTP_')) {
+            if (strtoupper($name) == 'CONTENT-TYPE') {
+                $name = 'CONTENT_TYPE';
+            } elseif (! starts_with($name, 'HTTP_')) {
                 $name = 'HTTP_' . strtr(strtoupper($name), '-', '_');
             }
 


### PR DESCRIPTION
See http://php.net/manual/en/reserved.variables.server.php#110763

Loosely relates to #208.  If you post or put a JSON body, Content-Type has to be correctly included or else the HTTP hijacker for the tests doesn't see the request as `isJson()`