### PR TITLE
Add dontSee() to CrawlerTrait

### DIFF
--- a/src/Testing/CrawlerTrait.php
+++ b/src/Testing/CrawlerTrait.php
@@ -287,6 +287,17 @@ trait CrawlerTrait
     }
 
     /**
+     * Assert that a given string is not seen on the page.
+     *
+     * @param  string  $text
+     * @return $this
+     */
+    protected function dontSee($text)
+    {
+        return $this->see($text, true);
+    }
+
+    /**
      * Assert that the response contains JSON.
      *
      * @param  array|null  $data


### PR DESCRIPTION
This was added to Laravel in [laravel/framework#9265](https://github.com/laravel/framework/pull/9265) and it would be great to see it in Lumen as well.