### PR TITLE
[5.1] Recursively transform data to array

### DIFF
--- a/src/Testing/CrawlerTrait.php
+++ b/src/Testing/CrawlerTrait.php
@@ -367,7 +367,7 @@ trait CrawlerTrait
             json_decode($this->response->getContent(), true)
         ));
 
-        foreach (array_sort_recursive($data) as $key => $value) {
+        foreach (array_sort_recursive(json_decode(json_encode($data), true)) as $key => $value) {
             $expected = $this->formatToExpectedJson($key, $value);
 
             $this->assertTrue(


### PR DESCRIPTION
The `array_sort_recursive()` helper was updated recently (actually the `Str` class method it points to was.  Now it has uncovered this issue (I presume because it is working better than previously).

The `seeJsonContains()` method uses `json_decode` on the response content passing in a value of `true` for the second param, which of course typecasts all objects to arrays.  If the response content is getting all objects typecast to arrays recursively, then the data array passed into the function should get the same treatment.

This wasn't causing an issue before the `array_sort_recursive()` update.  I presume that the nested arrays are now getting sorted properly and causing the objects not to match.
