### PR TITLE
Set up the path binding in the container during the bootstrapContaine…

### DIFF
--- a/src/Application.php
+++ b/src/Application.php
@@ -173,6 +173,7 @@ class Application extends Container implements ApplicationContract, HttpKernelIn
         static::setInstance($this);
 
         $this->instance('app', $this);
+        $this->instance('path', $this->path());
 
         $this->registerContainerAliases();
     }


### PR DESCRIPTION
…r in the Application class

Registering a Command that extends from Illuminate\Console\GeneratorCommand throws [ReflectionException] "Class path does not exist"

Digging a little bit I found out the GeneratorCommand class tries to access `$this->laravel['path']` during the getPath method on line 77.

I think we just need to set up the path in the container to fix this issue.
