### PR TITLE
[5.2] Updated Fast Route

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -40,7 +40,7 @@
         "illuminate/view": "5.2.*",
         "monolog/monolog": "~1.11",
         "mtdowling/cron-expression": "~1.0",
-        "nikic/fast-route": "0.4.*",
+        "nikic/fast-route": "0.6.*",
         "symfony/dom-crawler": "3.0.*",
         "symfony/http-kernel": "3.0.*",
         "symfony/http-foundation": "3.0.*",


### PR DESCRIPTION
I think it's much safer to update this in the next minor version. Updating this in a patch release might actually cause issues with dependency conflicts for people, preventing them receiving newer Lumen 5.1 releases. 0.6 might also have unexpected breakages since 0.4 and if people have been messing with route caching, which they might have been because custom Lumen setups can't be that uncommon.

TLDR: 5.2 is a much safer place to make this change than 5.1.