### PR TITLE
Removing incorrectly typehinted request parameter

### DIFF
--- a/src/Application.php
+++ b/src/Application.php
@@ -1323,7 +1323,7 @@ class Application extends Container implements ApplicationContract, HttpKernelIn
     protected function callLumenController($instance, $method, $routeInfo)
     {
         $middleware = $instance->getMiddlewareForMethod(
-            $this->make('request'), $method
+            $method
         );
 
         if (count($middleware) > 0) {

--- a/src/Routing/Controller.php
+++ b/src/Routing/Controller.php
@@ -2,8 +2,6 @@
 
 namespace Laravel\Lumen\Routing;
 
-use Illuminate\Http\Request;
-
 abstract class Controller
 {
     use DispatchesJobs, ValidatesRequests;
@@ -30,11 +28,10 @@ abstract class Controller
     /**
      * Get the middleware for a given method.
      *
-     * @param  Request  $request
      * @param  string  $method
      * @return array
      */
-    public function getMiddlewareForMethod(Request $request, $method)
+    public function getMiddlewareForMethod($method)
     {
         $middleware = [];
 


### PR DESCRIPTION
I ran into problems when trying to use behat with the [behat-lumen-extension](https://github.com/arisro/behat-lumen-extension) - the kernel was being loaded with a Symfony Request, but at one point in the lumen framework there was typehinting for the Illuminate\Http\Request, resulting in a fatal error.

The request object is never even used in that method or class though, so I thought it would be best to remove it completely. An alternative could just be to fix the typehint.

One other alternative could be to replace the Symfony request (that gets stored as Illuminate\Http\Request in the container) with the Illuminate equivalent using it's Request::createFromBase() method. I'm happy to change this either way as long as I can sort out the problem.