### PR TITLE
[5.1] Append middleware of action to group middleware

### DIFF
--- a/src/Application.php
+++ b/src/Application.php
@@ -1071,7 +1071,7 @@ class Application extends Container implements ApplicationContract, HttpKernelIn
     {
         if (isset($this->groupAttributes['middleware'])) {
             if (isset($action['middleware'])) {
-                $action['middleware'] .= '|'.$this->groupAttributes['middleware'];
+                $action['middleware'] = $this->groupAttributes['middleware'].'|'.$action['middleware'];
             } else {
                 $action['middleware'] = $this->groupAttributes['middleware'];
             }


### PR DESCRIPTION
The middleware of a route should be appended to the middleware of it's group.