### PR TITLE
Set DB_CONNECTION env variable to Queue failed default database

### DIFF
--- a/config/queue.php
+++ b/config/queue.php
@@ -87,7 +87,7 @@ return [
     */
 
     'failed' => [
-        'database' => 'mysql', 'table' => 'failed_jobs',
+        'database' => env('DB_CONNECTION', 'mysql'), 'table' => 'failed_jobs',
     ],
 
 ];


### PR DESCRIPTION
Found out this bug when I tried to flush the queue, when I had pgsql as default db-connection.