### PR TITLE
Provide secure option to UrlGenerator->route() and adhere to forceSchema if applied

### DIFF
--- a/src/Routing/UrlGenerator.php
+++ b/src/Routing/UrlGenerator.php
@@ -187,11 +187,12 @@ class UrlGenerator
      *
      * @param  string  $name
      * @param  mixed   $parameters
+     * @param  bool    $secure
      * @return string
      *
      * @throws \InvalidArgumentException
      */
-    public function route($name, $parameters = [])
+    public function route($name, $parameters = [], $secure = null)
     {
         if (! isset($this->app->namedRoutes[$name])) {
             throw new \InvalidArgumentException("Route [{$name}] not defined.");
@@ -205,7 +206,7 @@ class UrlGenerator
             return isset($parameters[$m[1]]) ? array_pull($parameters, $m[1]) : $m[0];
         }, $uri);
 
-        $uri = $this->to($uri, []);
+        $uri = $this->to($uri, [], $secure);
 
         if (! empty($parameters)) {
             $uri .= '?'.http_build_query($parameters);

--- a/src/Routing/UrlGenerator.php
+++ b/src/Routing/UrlGenerator.php
@@ -187,7 +187,7 @@ class UrlGenerator
      *
      * @param  string  $name
      * @param  mixed   $parameters
-     * @param  bool    $secure
+     * @param  bool|null  $secure
      * @return string
      *
      * @throws \InvalidArgumentException

--- a/src/Routing/UrlGenerator.php
+++ b/src/Routing/UrlGenerator.php
@@ -240,7 +240,7 @@ class UrlGenerator
     {
         if (is_null($secure)) {
             if (is_null($this->cachedScheme)) {
-                $this->cachedScheme = $this->app->make('request')->getScheme().'://';
+                $this->cachedScheme = $this->getScheme($secure);
             }
 
             return $this->cachedScheme;


### PR DESCRIPTION
I use the singleton UrlGenerator instance to generate links back to my application using named routes and my situation requires generated urls be https regardless of the incoming request protocol.

UrlGenerator does not currently support this functionality via the `route()` method as it does not provide a secure parameter and additionally, it does not honour the `forceSchema()` functionality.

> A case where you would need to override the incoming request protocol would be in a load balanced environment that terminates https at the load balancer. The consumers of an application would be using https, but internally the web servers would receive http messages from the load balancer.

## Quick example

The only way to attempt to force https currently is via `forceSchema()` which is ignored by `route()`.

My expectation of the following code is to return a url with the `https` scheme:

```php
    app('url')->forceSchema('https');
    $selfLink = app('url')->route('cafe', ['id' => 1]);
```

The reason why I'm not getting what I expect is straight forward:

- `route()` internally calls `to()` [without the `$secure` parameter](https://github.com/laravel/lumen-framework/blob/5.1/src/Routing/UrlGenerator.php#L208).
- `to()` uses `getSchemeForUrl(null)` 
- `getSchemeForUrl()` [defers to the current request](https://github.com/laravel/lumen-framework/blob/5.1/src/Routing/UrlGenerator.php#L242) when no $secure value is present.
- `getSchemeForUrl()` does not use [`getScheme()`](https://github.com/laravel/lumen-framework/blob/5.1/src/Routing/UrlGenerator.php#L165) internally, bypassing the functionality provided by `forceSchema()`.

This pull request aims to solve both issues outlined above while reducing duplication and maintaining the same default behavour. 

Cheers!