### PR TITLE
Logs : Be abble to change log file path and name

### DIFF
--- a/src/Application.php
+++ b/src/Application.php
@@ -641,7 +641,7 @@ class Application extends Container implements ApplicationContract, HttpKernelIn
     protected function getMonologHandler()
     {
         $logPath = env('APP_LOG_PATH', storage_path('logs/lumen.log'));
-        
+
         return (new StreamHandler($logPath, Logger::DEBUG))
                             ->setFormatter(new LineFormatter(null, null, true, true));
     }


### PR DESCRIPTION
Hi !
I'm using Lumen as a micro service with Docker. I need to be able to write logs to `php://stdout` to facilitate log aggregation between services. I suggest to add an env. var. `APP_LOG_PATH` default to `storage/logs/lumen.log` as it is hardcoded now.