### PR TITLE
Replace storage_path with database_path helper

### DIFF
--- a/config/database.php
+++ b/config/database.php
@@ -53,7 +53,7 @@ return [
 
         'sqlite' => [
             'driver'   => 'sqlite',
-            'database' => env('DB_DATABASE', storage_path('database.sqlite')),
+            'database' => env('DB_DATABASE', database_path('database.sqlite')),
             'prefix'   => env('DB_PREFIX', ''),
         ],
 


### PR DESCRIPTION
According to the docs, the sqlite database should be located within the "database" folder.