### PR TITLE
[5.2] Changed $e to $fe in render method.

### DIFF
--- a/src/Exceptions/Handler.php
+++ b/src/Exceptions/Handler.php
@@ -68,7 +68,7 @@ class Handler implements ExceptionHandler
      */
     public function render($request, Exception $e)
     {
-        $e = FlattenException::create($e);
+        $fe = FlattenException::create($e);
 
         $handler = new SymfonyExceptionHandler(env('APP_DEBUG', false));
 


### PR DESCRIPTION
Good Evening!
I see that tests are currently failing on dev-master.  It appears that either the variable `$e` was meant to be `$fe` or the places in which `$fe` are used should be `$e` instead.

Take care,
Nicholas