### PR TITLE
[5.1] Generate a URL to an application asset from a root domain such as CDN etc.

### DIFF
--- a/src/Routing/UrlGenerator.php
+++ b/src/Routing/UrlGenerator.php
@@ -133,6 +133,24 @@ class UrlGenerator
     }
 
     /**
+     * Generate a URL to an application asset from a root domain such as CDN etc.
+     *
+     * @param  string  $root
+     * @param  string  $path
+     * @param  bool|null  $secure
+     * @return string
+     */
+    public function assetFrom($root, $path, $secure = null)
+    {
+        // Once we get the root URL, we will check to see if it contains an index.php
+        // file in the paths. If it does, we will remove it since it is not needed
+        // for asset paths, but only for routes to endpoints in the application.
+        $root = $this->getRootUrl($this->getScheme($secure), $root);
+
+        return $this->removeIndex($root).'/'.trim($path, '/');
+    }
+
+    /**
      * Remove the index.php file from a path.
      *
      * @param  string  $root


### PR DESCRIPTION
This would simplify generating asset when you need to specify different root domain/url as the request. Alternative to laravel/framework#10550 PR.

Signed-off-by: crynobone <crynobone@gmail.com>