### PR TITLE
[5.1] Allow getting path to configuration directory

### DIFF
--- a/src/Application.php
+++ b/src/Application.php
@@ -844,19 +844,30 @@ class Application extends Container implements ApplicationContract, HttpKernelIn
     }
 
     /**
-     * Get the path to the given configuration file.
+     * Get the path to the given configuration file, or to the directory if the argument is 
+     * empty.
      *
      * @param  string  $name
      * @return string
      */
-    protected function getConfigurationPath($name)
+    public function getConfigurationPath($name = null)
     {
-        $appConfigPath = ($this->configPath ?: $this->basePath('config')).'/'.$name.'.php';
+        if (! $name) {
+            $appConfigDir = ($this->configPath ?: $this->basePath('config')).'/';
 
-        if (file_exists($appConfigPath)) {
-            return $appConfigPath;
-        } elseif (file_exists($path = __DIR__.'/../config/'.$name.'.php')) {
-            return $path;
+            if (file_exists($appConfigDir)) {
+                return $appConfigDir;
+            } elseif (file_exists($path = __DIR__.'/../config/')) {
+                return $path;
+            }
+        } else {
+            $appConfigPath = ($this->configPath ?: $this->basePath('config')).'/'.$name.'.php';
+
+            if (file_exists($appConfigPath)) {
+                return $appConfigPath;
+            } elseif (file_exists($path = __DIR__.'/../config/'.$name.'.php')) {
+                return $path;
+            }
         }
     }
 


### PR DESCRIPTION
Right now in order to get the configuration directory's path, you need to extend `Application` and access the `protected $appConfigDir` directly. This PR extends `getConfigurationPath()` to accept an empty string and return the config path in the case, and allow public access at the same time. 