### PR TITLE
Provide ability to customize the cache prefix

### DIFF
--- a/config/cache.php
+++ b/config/cache.php
@@ -70,6 +70,6 @@ return [
     |
     */
 
-    'prefix' => 'laravel',
+    'prefix' => env('CACHE_PREFIX', 'laravel'),
 
 ];


### PR DESCRIPTION
To prevent cache key collisions when running multiple Laravel/Lumen apps on the same server, I would like to be able to customize the cache prefix.