### PR TITLE
Throw a NotFoundHttpException if the route closure is not passed.

### DIFF
--- a/src/Application.php
+++ b/src/Application.php
@@ -1308,6 +1308,8 @@ class Application extends Container implements ApplicationContract, HttpKernelIn
                 $closure = $value->bindTo(new Routing\Closure);
                 break;
             }
+            
+            throw new NotFoundHttpException;
         }
 
         try {


### PR DESCRIPTION
When both the closure and the 'uses' key are not passed to the route, the $closure variable stays undefined. This fix will throw a NotFoundHttpException when both are not present.