### PR TITLE
[5.2] Use database as default auth driver

### DIFF
--- a/config/auth.php
+++ b/config/auth.php
@@ -15,7 +15,7 @@ return [
     |
     */
 
-    'driver' => env('AUTH_DRIVER', 'eloquent'),
+    'driver' => env('AUTH_DRIVER', 'database'),
 
     /*
     |--------------------------------------------------------------------------


### PR DESCRIPTION
Eloquent is disabled by default, so database is more suitable here.