### PR TITLE
Change type-hinting of Redirector and URL Generator class

### DIFF
--- a/src/Http/Redirector.php
+++ b/src/Http/Redirector.php
@@ -2,8 +2,10 @@
 
 namespace Laravel\Lumen\Http;
 
-use Laravel\Lumen\Application;
+use Illuminate\Contracts\Foundation\Application;
 use Illuminate\Http\RedirectResponse;
+use Laravel\Lumen\Application as Lumen;
+use InvalidArgumentException;
 
 class Redirector
 {
@@ -22,6 +24,11 @@ class Redirector
      */
     public function __construct(Application $app)
     {
+        // Optionally check for Lumen Application instance
+        if (! $app instanceof Lumen) {
+            throw new InvalidArgumentException('The [Laravel\\Lumen\\Http\\Redirector] requires an instance of Lumen to run.');
+        }
+
         $this->app = $app;
     }
 

--- a/src/Routing/UrlGenerator.php
+++ b/src/Routing/UrlGenerator.php
@@ -2,8 +2,10 @@
 
 namespace Laravel\Lumen\Routing;
 
-use Laravel\Lumen\Application;
+use Illuminate\Contracts\Foundation\Application;
 use Illuminate\Contracts\Routing\UrlRoutable;
+use Laravel\Lumen\Application as Lumen;
+use InvalidArgumentException;
 
 class UrlGenerator
 {
@@ -43,6 +45,10 @@ class UrlGenerator
      */
     public function __construct(Application $app)
     {
+        if (! $app instanceof Lumen) {
+            throw new InvalidArgumentException('The [Laravel\\Lumen\\Routing\\UrlGenerator] requires an instance of Lumen to run.');
+        }
+
         $this->app = $app;
     }
 


### PR DESCRIPTION
So, I try to inject the Redirector instance to a class and I ended up with two instances of `Laravel\Lumen\Application`, because the `Laravel\Lumen\Application` that is initialized through the `bootstrap/app.php` is bound to the `Illuminate\Contracts\Foundation\Application` and not to `Laravel\Lumen\Application`. This is also related to issue #255 

Example:
```php
// bootstrap/app.php
  
<?php
$app->get('/auth', [
    'as' => 'admin.auth',
    'uses' => 'AuthController@admin'
]);
  
  
// app/Http/Middleware/OnlyAllowAdminThrough.php
  
<?php

namespace App\Http\Middleware;

use Laravel\Lumen\Http\Redirector;

class OnlyAllowAdminThrough
{
    public function __construct(Redirector $redirect)
    {
        $this->redirect = $redirect;
    }

    public function handle($request, Closure $next = null)
    {
         if ( ! $request->session->has('is_admin'))
         {
             return $this->redirect->route('admin.auth');
         }

         return $next($request);
    }
}
```

On the Code above, we will not have the Named Route `admin.auth` because a new Lumen Application is instantiated when injecting `Redirector` to the class. For now, to overcome this problem, I just bound the `$app` instance to the `Laravel\Lumen\Application` singleton in `bootstrap/app.php`, but I thought I might send a pull request too, because I believe this behavior is not intended.