### PR TITLE
Change Application::loadComponent() method visibility to public.

### DIFF
--- a/src/Application.php
+++ b/src/Application.php
@@ -486,7 +486,7 @@ class Application extends Container
      * @param  string|null  $return
      * @return mixed
      */
-    protected function loadComponent($config, $providers, $return = null)
+    public function loadComponent($config, $providers, $return = null)
     {
         $this->configure($config);
 


### PR DESCRIPTION
This would make it slightly easier to re-add removed components in 5.2 in the Lumen bootstrap file such as.

```php
$app->singleton('view', function ($app) {
    return $app->loadComponent('view', 'Illuminate\View\ViewServiceProvider');
});
```