### PR TITLE
Fix #298

### DIFF
--- a/src/Application.php
+++ b/src/Application.php
@@ -925,6 +925,10 @@ class Application extends Container implements ApplicationContract, HttpKernelIn
     {
         $parentGroupAttributes = $this->groupAttributes;
 
+        if (isset($attributes['middleware']) && is_string($attributes['middleware'])) {
+            $attributes['middleware'] = explode('|', $attributes['middleware']);
+        }
+
         $this->groupAttributes = $attributes;
 
         call_user_func($callback, $this);
@@ -1058,6 +1062,10 @@ class Application extends Container implements ApplicationContract, HttpKernelIn
             return [$action];
         }
 
+        if (isset($action['middleware']) && is_string($action['middleware'])) {
+            $action['middleware'] = explode('|', $action['middleware']);
+        }
+
         return $action;
     }
 
@@ -1099,7 +1107,7 @@ class Application extends Container implements ApplicationContract, HttpKernelIn
     {
         if (isset($this->groupAttributes['middleware'])) {
             if (isset($action['middleware'])) {
-                $action['middleware'] = $this->groupAttributes['middleware'].'|'.$action['middleware'];
+                $action['middleware'] = array_merge($this->groupAttributes['middleware'], $action['middleware']);
             } else {
                 $action['middleware'] = $this->groupAttributes['middleware'];
             }

--- a/tests/FullApplicationTest.php
+++ b/tests/FullApplicationTest.php
@@ -133,7 +133,7 @@ class ExampleTest extends PHPUnit_Framework_TestCase
     {
         $app = new Application;
 
-        $app->routeMiddleware(['foo' => 'LumenTestMiddleware']);
+        $app->routeMiddleware(['foo' => 'LumenTestMiddleware', 'passing' => 'LumenTestPlainMiddleware']);
 
         $app->get('/', function () {
             return response('Hello World');
@@ -143,11 +143,27 @@ class ExampleTest extends PHPUnit_Framework_TestCase
             return response('Hello World');
         }]);
 
+        $app->get('/bar', ['middleware' => ['foo'], function () {
+            return response('Hello World');
+        }]);
+
+        $app->get('/fooBar', ['middleware' => 'passing|foo', function () {
+            return response('Hello World');
+        }]);
+
         $response = $app->handle(Request::create('/', 'GET'));
         $this->assertEquals(200, $response->getStatusCode());
         $this->assertEquals('Hello World', $response->getContent());
 
         $response = $app->handle(Request::create('/foo', 'GET'));
+        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertEquals('Middleware', $response->getContent());
+
+        $response = $app->handle(Request::create('/bar', 'GET'));
+        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertEquals('Middleware', $response->getContent());
+
+        $response = $app->handle(Request::create('/fooBar', 'GET'));
         $this->assertEquals(200, $response->getStatusCode());
         $this->assertEquals('Middleware', $response->getContent());
     }
@@ -172,9 +188,9 @@ class ExampleTest extends PHPUnit_Framework_TestCase
     {
         $app = new Application;
 
-        $app->routeMiddleware(['foo' => 'LumenTestParameterizedMiddleware']);
+        $app->routeMiddleware(['foo' => 'LumenTestParameterizedMiddleware', 'passing' => 'LumenTestPlainMiddleware']);
 
-        $app->get('/', ['middleware' => 'foo:bar,boom', function () {
+        $app->get('/', ['middleware' => 'passing|foo:bar,boom', function () {
             return response('Hello World');
         }]);
 
@@ -188,7 +204,7 @@ class ExampleTest extends PHPUnit_Framework_TestCase
     {
         $app = new Application;
 
-        $app->routeMiddleware(['foo' => 'LumenTestMiddleware']);
+        $app->routeMiddleware(['foo' => 'LumenTestMiddleware', 'bar' => 'LumenTestMiddleware']);
 
         $app->group(['middleware' => 'foo'], function ($app) {
             $app->get('/', function () {
@@ -196,6 +212,18 @@ class ExampleTest extends PHPUnit_Framework_TestCase
             });
             $app->group([], function () {});
             $app->get('/fooBar', function () {
+                return 'Hello World';
+            });
+        });
+
+        $app->group(['middleware' => ['foo']], function ($app) {
+            $app->get('/fooFoo', function () {
+                return 'Hello World';
+            });
+        });
+
+        $app->group(['middleware' => 'bar|foo'], function ($app) {
+            $app->get('/fooFooBar', function () {
                 return 'Hello World';
             });
         });
@@ -212,11 +240,56 @@ class ExampleTest extends PHPUnit_Framework_TestCase
         $this->assertEquals(200, $response->getStatusCode());
         $this->assertEquals('Hello World', $response->getContent());
 
+        $response = $app->handle(Request::create('/fooFoo', 'GET'));
+        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertEquals('Middleware', $response->getContent());
+
+        $response = $app->handle(Request::create('/fooFooBar', 'GET'));
+        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertEquals('Middleware', $response->getContent());
+
         $response = $app->handle(Request::create('/fooBar', 'GET'));
         $this->assertEquals(200, $response->getStatusCode());
         $this->assertEquals('Middleware', $response->getContent());
     }
 
+    public function testGroupRouteNestedMiddleware()
+    {
+        $app = new Application;
+
+        $app->routeMiddleware(['passing' => 'LumenTestPlainMiddleware', 'bar' => 'LumenTestMiddleware']);
+
+        $app->group(['middleware' => 'passing'], function ($app) {
+            $app->get('/foo', ['middleware' => 'bar', function () {
+                return 'Hello World';
+            }]);
+        });
+
+
+        $app->group(['middleware' => ['passing']], function ($app) {
+            $app->get('/bar', ['middleware' => ['bar'], function () {
+                return 'Hello World';
+            }]);
+        });
+
+        $app->group(['middleware' => ['passing']], function ($app) {
+            $app->get('/fooBar', ['middleware' => 'passing|bar', function () {
+                return 'Hello World';
+            }]);
+        });
+
+        $response = $app->handle(Request::create('/foo', 'GET'));
+        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertEquals('Middleware', $response->getContent());
+
+        $response = $app->handle(Request::create('/bar', 'GET'));
+        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertEquals('Middleware', $response->getContent());
+
+        $response = $app->handle(Request::create('/fooBar', 'GET'));
+        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertEquals('Middleware', $response->getContent());
+    }
     public function testWithMiddlewareDisabled()
     {
         $app = new Application;

--- a/tests/FullApplicationTest.php
+++ b/tests/FullApplicationTest.php
@@ -265,7 +265,6 @@ class ExampleTest extends PHPUnit_Framework_TestCase
             }]);
         });
 
-
         $app->group(['middleware' => ['passing']], function ($app) {
             $app->get('/bar', ['middleware' => ['bar'], function () {
                 return 'Hello World';
@@ -290,6 +289,7 @@ class ExampleTest extends PHPUnit_Framework_TestCase
         $this->assertEquals(200, $response->getStatusCode());
         $this->assertEquals('Middleware', $response->getContent());
     }
+
     public function testWithMiddlewareDisabled()
     {
         $app = new Application;


### PR DESCRIPTION
Fixes #298 
Middleware specification now allows using '|' as a separator, or passing an array.
Added new assertions to make sure middlewares as array and using '|' separator are respected.

P.S : I would like to request a config file for StyleCI so that we can run CS checks on our repos also.