### PR TITLE
[5.2] Bumped suggested phpdotenv version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -47,7 +47,7 @@
         "mockery/mockery": "~0.9"
     },
     "suggest": {
-        "vlucas/phpdotenv": "Required to use .env files (~2.0)."
+        "vlucas/phpdotenv": "Required to use .env files (~2.2)."
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
This version has the new exceptions. I'd like to update the default app in 5.2 to catch these better like laravel/framework does.