### PR TITLE
[5.2] Add Hash facade.

### DIFF
--- a/src/Application.php
+++ b/src/Application.php
@@ -576,6 +576,7 @@ class Application extends Container
             class_alias('Illuminate\Support\Facades\DB', 'DB');
             class_alias('Illuminate\Support\Facades\Event', 'Event');
             class_alias('Illuminate\Support\Facades\Gate', 'Gate');
+            class_alias('Illuminate\Support\Facades\Hash', 'Hash');
             class_alias('Illuminate\Support\Facades\Log', 'Log');
             class_alias('Illuminate\Support\Facades\Queue', 'Queue');
             class_alias('Illuminate\Support\Facades\Schema', 'Schema');


### PR DESCRIPTION
Maybe I'm missing something, but neither `Hash` nor `bcrypt` are available within Lumen 5.2

Is there another recommended method or replacement? If so, apologies.