### PR TITLE
Bump requirement to v5.2.7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,7 @@
         "illuminate/queue": "5.2.*",
         "illuminate/support": "5.2.*",
         "illuminate/translation": "5.2.*",
-        "illuminate/validation": "5.2.*",
+        "illuminate/validation": "~5.2.7",
         "illuminate/view": "5.2.*",
         "monolog/monolog": "~1.11",
         "mtdowling/cron-expression": "~1.0",


### PR DESCRIPTION
`App\Exceptions\Handler` uses `Illuminate\Validation\ValidationException` which is only available starting from 5.2.7.