### PR TITLE
Brings back app()->getRoutes method

### DIFF
--- a/src/Application.php
+++ b/src/Application.php
@@ -675,16 +675,6 @@ class Application extends Container
     }
 
     /**
-      * Get the raw routes for the application.
-      *
-      * @return array
-      */
-     public function getRoutes()
-     {
-         return $this->routes;
-     }
-
-    /**
      * Register the core container aliases.
      *
      * @return void

--- a/src/Application.php
+++ b/src/Application.php
@@ -675,6 +675,16 @@ class Application extends Container
     }
 
     /**
+      * Get the raw routes for the application.
+      *
+      * @return array
+      */
+     public function getRoutes()
+     {
+         return $this->routes;
+     }
+
+    /**
      * Register the core container aliases.
      *
      * @return void

--- a/src/Concerns/RoutesRequests.php
+++ b/src/Concerns/RoutesRequests.php
@@ -652,4 +652,14 @@ trait RoutesRequests
 
         return '/'.trim(str_replace('?'.$query, '', $_SERVER['REQUEST_URI']), '/');
     }
+
+    /**
+      * Get the raw routes for the application.
+      *
+      * @return array
+      */
+     public function getRoutes()
+     {
+         return $this->routes;
+     }
 }

--- a/src/Concerns/RoutesRequests.php
+++ b/src/Concerns/RoutesRequests.php
@@ -654,12 +654,12 @@ trait RoutesRequests
     }
 
     /**
-      * Get the raw routes for the application.
-      *
-      * @return array
-      */
-     public function getRoutes()
-     {
-         return $this->routes;
-     }
+     * Get the raw routes for the application.
+     *
+     * @return array
+     */
+    public function getRoutes()
+    {
+        return $this->routes;
+    }
 }


### PR DESCRIPTION
The `getRoutes` method has been removed as part of a [code cleanup](https://github.com/laravel/lumen-framework/commit/82adca8e67269498387fd0090037e6c40821ef99).

As it was used by [some Lumen packages](https://github.com/appzcoder/lumen-route-list) this PR brings it back.