### PR TITLE
Fluent syntax to see status code

### DIFF
--- a/src/Testing/Concerns/MakesHttpRequests.php
+++ b/src/Testing/Concerns/MakesHttpRequests.php
@@ -280,6 +280,19 @@ trait MakesHttpRequests
     }
 
     /**
+     * Asserts that the status code of the response matches the given code.
+     *
+     * @param  int  $status
+     * @return $this
+     */
+    protected function seeStatusCode($status)
+    {
+        $this->assertEquals($status, $this->response->getStatusCode());
+
+        return $this;
+    }
+
+    /**
      * Format the given key and value into a JSON string for expectation checks.
      *
      * @param  string  $key


### PR DESCRIPTION
`seeStatusCode` method was removed during [5.2 code cleanup](https://github.com/laravel/lumen-framework/commit/b63c9525740082c68752efd4bb5aa421dda73213) that deleted `src/Testing/CrawlerTrait.php` file.

It seems to make sense to keep this method so unit tests can keep checking returned status code and response using fluent approach.

Implementation simply copied from Lumen 5.1.
Related to #310.