### PR TITLE
Fix missing binding for 'cache.store'

### DIFF
--- a/src/Application.php
+++ b/src/Application.php
@@ -714,6 +714,7 @@ class Application extends Container
         'Illuminate\Contracts\Broadcasting\Broadcaster' => 'registerBroadcastingBindings',
         'Illuminate\Contracts\Bus\Dispatcher' => 'registerBusBindings',
         'cache' => 'registerCacheBindings',
+        'cache.store' => 'registerCacheBindings',
         'Illuminate\Contracts\Cache\Factory' => 'registerCacheBindings',
         'Illuminate\Contracts\Cache\Repository' => 'registerCacheBindings',
         'composer' => 'registerComposerBindings',


### PR DESCRIPTION
Not possible to use cache on a fresh Lumen installation. ReflectionException “Class cache.store does not exist“ appears due to missing binding for 'cache.store‘. The following pull request should fix the issue.