### PR TITLE
Adds missing \Exception namespace

### DIFF
--- a/src/Testing/TestCase.php
+++ b/src/Testing/TestCase.php
@@ -2,6 +2,7 @@
 
 namespace Laravel\Lumen\Testing;
 
+use Exception;
 use Mockery;
 use PHPUnit_Framework_TestCase;
 use Illuminate\Support\Facades\Facade;


### PR DESCRIPTION
While mocking events and running phpunit the following error appeared due to the missing namespace declaration „Error: Class 'Laravel\Lumen\Testing\Exception' not found“. The following pull request will fix it.