### PR TITLE
[5.2] Return an Illuminate response from the exception handler

### DIFF
--- a/src/Exceptions/Handler.php
+++ b/src/Exceptions/Handler.php
@@ -3,7 +3,7 @@
 namespace Laravel\Lumen\Exceptions;
 
 use Exception;
-use Symfony\Component\HttpFoundation\Response;
+use Illuminate\Http\Response;
 use Illuminate\Validation\ValidationException;
 use Illuminate\Contracts\Debug\ExceptionHandler;
 use Illuminate\Auth\Access\AuthorizationException;

--- a/tests/FullApplicationTest.php
+++ b/tests/FullApplicationTest.php
@@ -208,6 +208,20 @@ class FullApplicationTest extends PHPUnit_Framework_TestCase
         $this->assertEquals(405, $response->getStatusCode());
     }
 
+    public function testUncaughtExceptionResponse()
+    {
+        $app = new Application;
+        $app->instance('Illuminate\Contracts\Debug\ExceptionHandler', $mock = m::mock('Laravel\Lumen\Exceptions\Handler[report]'));
+        $mock->shouldIgnoreMissing();
+
+        $app->get('/', function () {
+            throw new \RuntimeException('app exception');
+        });
+
+        $response = $app->handle(Request::create('/', 'GET'));
+        $this->assertInstanceOf('Illuminate\Http\Response', $response);
+    }
+
     public function testGeneratingUrls()
     {
         $app = new Application;


### PR DESCRIPTION
5.2 changed the return type of `Laravel\Lumen\Exceptions\Handler@render` from an [Illuminate Response](https://github.com/laravel/lumen-framework/blob/5.1/src/Exceptions/Handler.php#L72) to a [Symfony Response](https://github.com/laravel/lumen-framework/blob/5.2/src/Exceptions/Handler.php#L93).

After upgrading to 5.2 my after middleware started failing because it was expecting an Illuminate response.

This PR restores the original behavior and returns an Illuminate response.  I added a simple test too.

Thanks!