### PR TITLE
Add support for PSR-7 requests and responses.

### DIFF
--- a/src/Application.php
+++ b/src/Application.php
@@ -12,7 +12,9 @@ use Monolog\Formatter\LineFormatter;
 use Illuminate\Filesystem\Filesystem;
 use Illuminate\Support\Facades\Facade;
 use Illuminate\Support\ServiceProvider;
+use Zend\Diactoros\Response as PsrResponse;
 use Illuminate\Config\Repository as ConfigRepository;
+use Symfony\Bridge\PsrHttpMessage\Factory\DiactorosFactory;
 
 class Application extends Container
 {
@@ -433,6 +435,30 @@ class Application extends Container
     }
 
     /**
+     * Register container bindings for the PSR-7 request implementation.
+     *
+     * @return void
+     */
+    protected function registerPsrRequestBindings()
+    {
+        $this->singleton('Psr\Http\Message\ServerRequestInterface', function () {
+            return (new DiactorosFactory)->createRequest($this->make('request'));
+        });
+    }
+
+    /**
+     * Register container bindings for the PSR-7 response implementation.
+     *
+     * @return void
+     */
+    protected function registerPsrResponseBindings()
+    {
+        $this->singleton('Psr\Http\Message\ResponseInterface', function () {
+            return new PsrResponse();
+        });
+    }
+
+    /**
      * Register container bindings for the application.
      *
      * @return void
@@ -735,6 +761,8 @@ class Application extends Container
         'Illuminate\Contracts\Queue\Factory' => 'registerQueueBindings',
         'Illuminate\Contracts\Queue\Queue' => 'registerQueueBindings',
         'request' => 'registerRequestBindings',
+        'Psr\Http\Message\ServerRequestInterface' => 'registerPsrRequestBindings',
+        'Psr\Http\Message\ResponseInterface' => 'registerPsrResponseBindings',
         'Illuminate\Http\Request' => 'registerRequestBindings',
         'translator' => 'registerTranslationBindings',
         'validator' => 'registerValidatorBindings',

--- a/src/Concerns/RoutesRequests.php
+++ b/src/Concerns/RoutesRequests.php
@@ -15,6 +15,8 @@ use Symfony\Component\HttpKernel\HttpKernelInterface;
 use Symfony\Component\HttpFoundation\BinaryFileResponse;
 use Laravel\Lumen\Routing\Controller as LumenController;
 use Symfony\Component\HttpFoundation\Request as SymfonyRequest;
+use Psr\Http\Message\ResponseInterface as PsrResponseInterface;
+use Symfony\Bridge\PsrHttpMessage\Factory\HttpFoundationFactory;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Symfony\Component\HttpFoundation\Response as SymfonyResponse;
 use Symfony\Component\HttpKernel\Exception\MethodNotAllowedHttpException;
@@ -626,7 +628,9 @@ trait RoutesRequests
      */
     public function prepareResponse($response)
     {
-        if (! $response instanceof SymfonyResponse) {
+        if ($response instanceof PsrResponseInterface) {
+            $response = (new HttpFoundationFactory)->createResponse($response);
+        } elseif (! $response instanceof SymfonyResponse) {
             $response = new Response($response);
         } elseif ($response instanceof BinaryFileResponse) {
             $response = $response->prepare(Request::capture());


### PR DESCRIPTION
Fixes issue #246.

I wrote a test but it won't pass unless I require --dev zend-diactoros and psr-http-message-bridge.  I didn't see them in the Laravel's composer.json so I left them out here.  Should I add them + the test?