### PR TITLE
Do not recreate dispatcher on every dispatch()

### DIFF
--- a/src/Concerns/RoutesRequests.php
+++ b/src/Concerns/RoutesRequests.php
@@ -407,7 +407,7 @@ trait RoutesRequests
      */
     protected function createDispatcher()
     {
-        return $this->dispatcher ?: \FastRoute\simpleDispatcher(function ($r) {
+        return $this->dispatcher = $this->dispatcher ?: \FastRoute\simpleDispatcher(function ($r) {
             foreach ($this->routes as $route) {
                 $r->addRoute($route['method'], $route['uri'], $route['action']);
             }


### PR DESCRIPTION
When I run repeatedly `$app->run($request);` app recreate dispatcher on each `dispatch()`, which have bad behaviour on performance. For me 130ms(now) => to 22ms(fixed).