### PR TITLE
Add suffix support to route groups

### DIFF
--- a/src/Concerns/RoutesRequests.php
+++ b/src/Concerns/RoutesRequests.php
@@ -195,7 +195,7 @@ trait RoutesRequests
             }
 
             if (isset($this->groupAttributes['suffix'])) {
-                $uri  = trim($uri, '/').trim($this->groupAttributes['suffix'], '/');
+                $uri = trim($uri, '/').trim($this->groupAttributes['suffix'], '/');
             }
 
             $action = $this->mergeGroupAttributes($action);

--- a/src/Concerns/RoutesRequests.php
+++ b/src/Concerns/RoutesRequests.php
@@ -194,6 +194,10 @@ trait RoutesRequests
                 $uri = trim($this->groupAttributes['prefix'], '/').'/'.trim($uri, '/');
             }
 
+            if (isset($this->groupAttributes['suffix'])) {
+                $uri  = trim($uri, '/').trim($this->groupAttributes['suffix'], '/');
+            }
+
             $action = $this->mergeGroupAttributes($action);
         }
 


### PR DESCRIPTION
Hello,

We were just looking at creating an API in lumen and noticed it would be really useful if we were able to specify a route suffix (in much the same way as the current route prefixes work). This would allow us to support users adding .xml/.json to the ends of our endpoints without us needing the repeat the regex for every route in our app.

Our own use case for the change looks roughly like:

```php
$app->group([ 'suffix'=> "[.{api_format:json|xml}]" ], function($app){
    $app->get('/foo', 'BlaController@foo');
    $app->get('/bar', 'BlaController@bar');
});
```
Which means `/foo`, `/foo.xml` and `/foo.json` endpoints are all valid for routes within the group.

Thanks,
Carl