### PR TITLE
[5.2] Allow route suffix

### DIFF
--- a/src/Concerns/RoutesRequests.php
+++ b/src/Concerns/RoutesRequests.php
@@ -195,7 +195,7 @@ trait RoutesRequests
             }
 
             if (isset($this->groupAttributes['suffix'])) {
-                $uri  = trim($uri, '/').trim($this->groupAttributes['suffix'], '/');
+                $uri = trim($uri, '/').trim($this->groupAttributes['suffix'], '/');
             }
 
             $action = $this->mergeGroupAttributes($action);

--- a/src/Concerns/RoutesRequests.php
+++ b/src/Concerns/RoutesRequests.php
@@ -195,7 +195,7 @@ trait RoutesRequests
             }
 
             if (isset($this->groupAttributes['suffix'])) {
-                $uri = trim($uri, '/').trim($this->groupAttributes['suffix'], '/');
+                $uri = trim($uri, '/').rtrim($this->groupAttributes['suffix'], '/');
             }
 
             $action = $this->mergeGroupAttributes($action);

--- a/src/Concerns/RoutesRequests.php
+++ b/src/Concerns/RoutesRequests.php
@@ -194,6 +194,10 @@ trait RoutesRequests
                 $uri = trim($this->groupAttributes['prefix'], '/').'/'.trim($uri, '/');
             }
 
+            if (isset($this->groupAttributes['suffix'])) {
+                $uri  = trim($uri, '/').trim($this->groupAttributes['suffix'], '/');
+            }
+
             $action = $this->mergeGroupAttributes($action);
         }
 

--- a/tests/FullApplicationTest.php
+++ b/tests/FullApplicationTest.php
@@ -358,6 +358,21 @@ class FullApplicationTest extends PHPUnit_Framework_TestCase
         $this->assertEquals('Middleware', $response->getContent());
     }
 
+    public function testBasicControllerDispatchingWithGroupSuffix()
+    {
+        $app = new Application;
+        $app->routeMiddleware(['test' => LumenTestMiddleware::class]);
+
+        $app->group(['suffix' => '.{format:json|xml}'], function ($app) {
+            $app->get('/show/{id}', 'LumenTestController@show');
+        });
+
+        $response = $app->handle(Request::create('/show/25.xml', 'GET'));
+
+        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertEquals('25', $response->getContent());
+    }
+
     public function testBasicControllerDispatchingWithMiddlewareIntercept()
     {
         $app = new Application;

--- a/tests/FullApplicationTest.php
+++ b/tests/FullApplicationTest.php
@@ -373,6 +373,21 @@ class FullApplicationTest extends PHPUnit_Framework_TestCase
         $this->assertEquals('25', $response->getContent());
     }
 
+     public function testBasicControllerDispatchingWithGroupAndSuffixWithPath()
+    {
+        $app = new Application;
+        $app->routeMiddleware(['test' => LumenTestMiddleware::class]);
+
+        $app->group(['suffix' => '/{format:json|xml}'], function ($app) {
+            $app->get('/show/{id}', 'LumenTestController@show');
+        });
+
+        $response = $app->handle(Request::create('/show/test/json', 'GET'));
+
+        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertEquals('test', $response->getContent());
+    }
+
     public function testBasicControllerDispatchingWithMiddlewareIntercept()
     {
         $app = new Application;

--- a/tests/FullApplicationTest.php
+++ b/tests/FullApplicationTest.php
@@ -373,7 +373,7 @@ class FullApplicationTest extends PHPUnit_Framework_TestCase
         $this->assertEquals('25', $response->getContent());
     }
 
-     public function testBasicControllerDispatchingWithGroupAndSuffixWithPath()
+    public function testBasicControllerDispatchingWithGroupAndSuffixWithPath()
     {
         $app = new Application;
         $app->routeMiddleware(['test' => LumenTestMiddleware::class]);


### PR DESCRIPTION
Resubmitted to 5.2 branch as requested in https://github.com/laravel/lumen-framework/pull/352

------

Hello,

We were just looking at creating an API in lumen and noticed it would be really useful if we were able to specify a route suffix (in much the same way as the current route prefixes work). This would allow us to support users adding .xml/.json to the ends of our endpoints without us needing the repeat the regex for every route in our app.

Our own use case for the change looks roughly like:

```php
$app->group([ 'suffix'=> "[.{api_format:json|xml}]" ], function($app){
    $app->get('/foo', 'BlaController@foo');
    $app->get('/bar', 'BlaController@bar');
});
```
Which means `/foo`, `/foo.xml` and `/foo.json` endpoints are all valid for routes within the group.

Thanks,
Carl