### PR TITLE
Add missing configuration for APC cache driver

### DIFF
--- a/config/cache.php
+++ b/config/cache.php
@@ -28,6 +28,10 @@ return [
 
     'stores' => [
 
+        'apc' => [
+            'driver' => 'apc',
+        ],
+
         'array' => [
             'driver' => 'array',
         ],


### PR DESCRIPTION
Without this entry, Lumen will throw `Cache store [apc] is not defined.`