### PR TITLE
[5.2] Add wildcard support to seeJsonStructure

### DIFF
--- a/src/Testing/Concerns/MakesHttpRequests.php
+++ b/src/Testing/Concerns/MakesHttpRequests.php
@@ -237,13 +237,21 @@ trait MakesHttpRequests
         }
 
         foreach ($structure as $key => $value) {
-            if (is_array($value)) {
+            if (is_array($value) && $key === '*') {
+                $this->assertInternalType('array', $responseData);
+
+                foreach ($responseData as $responseDataItem) {
+                    $this->seeJsonStructure($structure['*'], $responseDataItem);
+                }
+            } elseif (is_array($value)) {
                 $this->assertArrayHasKey($key, $responseData);
                 $this->seeJsonStructure($structure[$key], $responseData[$key]);
             } else {
                 $this->assertArrayHasKey($value, $responseData);
             }
         }
+
+        return $this;
     }
 
     /**


### PR DESCRIPTION
It has been added to Laravel but not Lumen: 
https://github.com/laravel/framework/blob/5.2/src/Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php#L252