### PR TITLE
Add DB_SCHEMA as env variable for postgres

### DIFF
--- a/config/database.php
+++ b/config/database.php
@@ -80,7 +80,7 @@ return [
             'password' => env('DB_PASSWORD', ''),
             'charset'  => 'utf8',
             'prefix'   => env('DB_PREFIX', ''),
-            'schema'   => 'public',
+            'schema'   => env('DB_SCHEMA', 'public'),
         ],
 
         'sqlsrv' => [


### PR DESCRIPTION
Making the database schema configurable via an environment variable.

Useful when running multiple schema's for various reasons, such as simplified testing infrastructure by using a test schema.