### PR TITLE
Expand env variables for all configs.

### DIFF
--- a/config/broadcasting.php
+++ b/config/broadcasting.php
@@ -37,7 +37,7 @@ return [
 
         'redis' => [
             'driver' => 'redis',
-            'connection' => 'default',
+            'connection' => env('BROADCAST_REDIS_CONNECTION', 'default'),
         ],
 
         'log' => [

--- a/config/cache.php
+++ b/config/cache.php
@@ -39,7 +39,7 @@ return [
         'database' => [
             'driver' => 'database',
             'table'  => env('CACHE_DATABASE_TABLE', 'cache'),
-            'connection' => null,
+            'connection' => env('CACHE_DATABASE_CONNECTION', null),
         ],
 
         'file' => [
@@ -58,7 +58,7 @@ return [
 
         'redis' => [
             'driver' => 'redis',
-            'connection' => 'default',
+            'connection' => env('CACHE_REDIS_CONNECTION', 'default'),
         ],
 
     ],

--- a/config/database.php
+++ b/config/database.php
@@ -64,11 +64,11 @@ return [
             'database'  => env('DB_DATABASE', 'forge'),
             'username'  => env('DB_USERNAME', 'forge'),
             'password'  => env('DB_PASSWORD', ''),
-            'charset'   => 'utf8',
-            'collation' => 'utf8_unicode_ci',
+            'charset'   => env('DB_CHARSET', 'utf8'),
+            'collation' => env('DB_COLLATION', 'utf8_unicode_ci'),
             'prefix'    => env('DB_PREFIX', ''),
             'timezone'  => env('DB_TIMEZONE', '+00:00'),
-            'strict'    => false,
+            'strict'    => env('DB_STRICT_MODE', false),
         ],
 
         'pgsql' => [
@@ -78,7 +78,7 @@ return [
             'database' => env('DB_DATABASE', 'forge'),
             'username' => env('DB_USERNAME', 'forge'),
             'password' => env('DB_PASSWORD', ''),
-            'charset'  => 'utf8',
+            'charset'  => env('DB_CHARSET', 'utf8'),
             'prefix'   => env('DB_PREFIX', ''),
             'schema'   => env('DB_SCHEMA', 'public'),
         ],

--- a/config/queue.php
+++ b/config/queue.php
@@ -37,8 +37,8 @@ return [
 
         'database' => [
             'driver' => 'database',
-            'table' => 'jobs',
-            'queue' => 'default',
+            'table'  => 'jobs',
+            'queue'  => 'default',
             'expire' => 60,
         ],
 
@@ -67,10 +67,10 @@ return [
         ],
 
         'redis' => [
-            'driver' => 'redis',
+            'driver'     => 'redis',
             'connection' => 'default',
-            'queue'  => 'default',
-            'expire' => 60,
+            'queue'      => 'default',
+            'expire'     => 60,
         ],
 
     ],
@@ -87,7 +87,8 @@ return [
     */
 
     'failed' => [
-        'database' => env('DB_CONNECTION', 'mysql'), 'table' => 'failed_jobs',
+        'database' => env('DB_CONNECTION', 'mysql'),
+        'table'    => env('QUEUE_FAILED_TABLE', 'failed_jobs'),
     ],
 
 ];


### PR DESCRIPTION
Make as many env variables for config entries as possible. This allows developers to override things without reimplementing the config files in their application for minor edits.

Also some minor code style things for array alignment in the queue config.