### PR TITLE
Revert "'API' isn't a supported driver"

### DIFF
--- a/config/auth.php
+++ b/config/auth.php
@@ -35,7 +35,7 @@ return [
     */
 
     'guards' => [
-        'api' => ['driver' => 'token'],
+        'api' => ['driver' => 'api'],
     ],
 
     /*


### PR DESCRIPTION
This reverts commit 2748c05c9d9bef64a0ec3ad4b119b1119833c408.

The commit in question breaks application using the lumen app skeleton. `api` is the defined provider through the first parameter in the [auth service provider](https://github.com/laravel/lumen/blob/master/app/Providers/AuthServiceProvider.php#L33). This means applications using the default will break with an `undefined index: providers` when attempting to just use the default service provider. We instead need to either revert this commit so the skeleton works (preferred method) or update the skeleton to use `token` instead of `api` for the `viaRequest` parameter.