### PR TITLE
Support charset for sqlsrv connection

### DIFF
--- a/config/database.php
+++ b/config/database.php
@@ -89,6 +89,7 @@ return [
             'database' => env('DB_DATABASE', 'forge'),
             'username' => env('DB_USERNAME', 'forge'),
             'password' => env('DB_PASSWORD', ''),
+            'charset'  => env('DB_CHARSET', 'utf8'),
             'prefix'   => env('DB_PREFIX', ''),
         ],
 


### PR DESCRIPTION
Simply bring this default connection to feature parity with other database connection types.

Currently things fall apart when talking to nvarchar and similar fields in sqlserver when those fields contain UTF-8 data. The encoding will be off an you need to hack mb_* logic around the fields to resolve this. Other parts of lumen support passing the character set into the connection string when its supplied and supported by the connection library(freetds). However currently the default connection logic does not support supplying that character set the way other connections do so this adds that support.