### PR TITLE
Consistent charset for sqlserver connection

### DIFF
--- a/config/database.php
+++ b/config/database.php
@@ -89,6 +89,7 @@ return [
             'database' => env('DB_DATABASE', 'forge'),
             'username' => env('DB_USERNAME', 'forge'),
             'password' => env('DB_PASSWORD', ''),
+            'charset'  => 'utf8',
             'prefix'   => env('DB_PREFIX', ''),
         ],
 


### PR DESCRIPTION
psuedo backport #368

This mostly aligns the SQL Server connection with other connections that already supply a UTF-8 character set to their connections.

Currently things fall apart when talking to nvarchar and similar fields in sqlserver when those fields contain UTF-8 data. The encoding will be off an you need to hack mb_* logic around the fields to resolve this. Other parts of lumen support passing the character set into the connection string when its supplied and supported by the connection library(freetds). However currently the default connection logic does not supply the character set the way other connections do. This supplies a more reasonable default.