### PR TITLE
[5.2] Set Request resolvers when request is provided

### DIFF
--- a/src/Application.php
+++ b/src/Application.php
@@ -426,12 +426,25 @@ class Application extends Container
     protected function registerRequestBindings()
     {
         $this->singleton('Illuminate\Http\Request', function () {
-            return Request::capture()->setUserResolver(function () {
-                return $this->make('auth')->user();
-            })->setRouteResolver(function () {
-                return $this->currentRoute;
-            });
+            return $this->configureRequest(Request::capture());
         });
+    }
+
+    /**
+     * Configure the given request instance for use with the application.
+     *
+     * @param \Illuminate\Http\Request $request
+     * @return \Illuminate\Http\Request
+     */
+    protected function configureRequest(Request $request)
+    {
+        $request->setUserResolver(function () {
+            return $this->make('auth')->user();
+        })->setRouteResolver(function () {
+            return $this->currentRoute;
+        });
+
+        return $request;
     }
 
     /**

--- a/src/Concerns/RoutesRequests.php
+++ b/src/Concerns/RoutesRequests.php
@@ -390,12 +390,13 @@ trait RoutesRequests
     /**
      * Parse the incoming request and return the method and path info.
      *
+     * @param \Illuminate\Http\Request $request
      * @return array
      */
     protected function parseIncomingRequest($request)
     {
         if ($request) {
-            $this->instance('Illuminate\Http\Request', $request);
+            $this->instance('Illuminate\Http\Request', $this->configureRequest($request));
             $this->ranServiceBinders['registerRequestBindings'] = true;
 
             return [$request->getMethod(), $request->getPathInfo()];

--- a/tests/FullApplicationTest.php
+++ b/tests/FullApplicationTest.php
@@ -451,6 +451,23 @@ class FullApplicationTest extends PHPUnit_Framework_TestCase
 
         $this->assertEquals(302, $response->getStatusCode());
     }
+
+    public function testRequestUser()
+    {
+        $app = new Application();
+
+        $app['auth']->viaRequest('api', function ($request) {
+            return new \Illuminate\Auth\GenericUser(['id' => 1234]);
+        });
+
+        $app->get('/', function (Illuminate\Http\Request $request) {
+            return $request->user()->getAuthIdentifier();
+        });
+
+        $response = $app->handle(Request::create('/', 'GET'));
+
+        $this->assertSame('1234', $response->getContent());
+    }
 }
 
 class LumenTestService


### PR DESCRIPTION
The default route resolver and user resolver were only being set if a request was not passed in.  I.E., the resolver would work if you called `$app->run()`, but not if you called `$app->run($request)`.

This causes `$request->route()` and `$request->user()` to return null when running tests, even though they work fine the rest of the time.