### PR TITLE
Allow for giving a connection on which to assert database checks

### DIFF
--- a/src/Testing/TestCase.php
+++ b/src/Testing/TestCase.php
@@ -120,9 +120,9 @@ abstract class TestCase extends PHPUnit_Framework_TestCase
     /**
      * Assert that a given where condition exists in the database.
      *
-     * @param  string $table
-     * @param  array $data
-     * @param  string $onConnection
+     * @param  string  $table
+     * @param  array  $data
+     * @param  string|null $onConnection
      * @return $this
      */
     protected function seeInDatabase($table, array $data, $onConnection = null)
@@ -139,9 +139,9 @@ abstract class TestCase extends PHPUnit_Framework_TestCase
     /**
      * Assert that a given where condition does not exist in the database.
      *
-     * @param  string $table
-     * @param  array $data
-     * @param  string $onConnection
+     * @param  string  $table
+     * @param  array  $data
+     * @param  string|null $onConnection
      * @return $this
      */
     protected function missingFromDatabase($table, array $data, $onConnection = null)
@@ -152,9 +152,9 @@ abstract class TestCase extends PHPUnit_Framework_TestCase
     /**
      * Assert that a given where condition does not exist in the database.
      *
-     * @param  string $table
-     * @param  array $data
-     * @param  string $onConnection
+     * @param  string  $table
+     * @param  array  $data
+     * @param  string|null $onConnection
      * @return $this
      */
     protected function notSeeInDatabase($table, array $data, $onConnection = null)

--- a/src/Testing/TestCase.php
+++ b/src/Testing/TestCase.php
@@ -120,13 +120,14 @@ abstract class TestCase extends PHPUnit_Framework_TestCase
     /**
      * Assert that a given where condition exists in the database.
      *
-     * @param  string  $table
-     * @param  array  $data
+     * @param  string $table
+     * @param  array $data
+     * @param  string $onConnection
      * @return $this
      */
-    protected function seeInDatabase($table, array $data)
+    protected function seeInDatabase($table, array $data, $onConnection = null)
     {
-        $count = $this->app->make('db')->table($table)->where($data)->count();
+        $count = $this->app->make('db')->connection($onConnection)->table($table)->where($data)->count();
 
         $this->assertGreaterThan(0, $count, sprintf(
             'Unable to find row in database table [%s] that matched attributes [%s].', $table, json_encode($data)
@@ -138,25 +139,27 @@ abstract class TestCase extends PHPUnit_Framework_TestCase
     /**
      * Assert that a given where condition does not exist in the database.
      *
-     * @param  string  $table
-     * @param  array  $data
+     * @param  string $table
+     * @param  array $data
+     * @param  string $onConnection
      * @return $this
      */
-    protected function missingFromDatabase($table, array $data)
+    protected function missingFromDatabase($table, array $data, $onConnection = null)
     {
-        return $this->notSeeInDatabase($table, $data);
+        return $this->notSeeInDatabase($table, $data, $onConnection);
     }
 
     /**
      * Assert that a given where condition does not exist in the database.
      *
-     * @param  string  $table
-     * @param  array  $data
+     * @param  string $table
+     * @param  array $data
+     * @param  string $onConnection
      * @return $this
      */
-    protected function notSeeInDatabase($table, array $data)
+    protected function notSeeInDatabase($table, array $data, $onConnection = null)
     {
-        $count = $this->app->make('db')->table($table)->where($data)->count();
+        $count = $this->app->make('db')->connection($onConnection)->table($table)->where($data)->count();
 
         $this->assertEquals(0, $count, sprintf(
             'Found unexpected records in database table [%s] that matched attributes [%s].', $table, json_encode($data)


### PR DESCRIPTION
This allows to specify a database connection on which to test database assertions like `seeInDatabase`