### PR TITLE
Set route resolver after route is found.

### DIFF
--- a/src/Concerns/RoutesRequests.php
+++ b/src/Concerns/RoutesRequests.php
@@ -460,6 +460,10 @@ trait RoutesRequests
     {
         $this->currentRoute = $routeInfo;
 
+        $this['request']->setRouteResolver(function () {
+            return $this->currentRoute;
+        });
+
         $action = $routeInfo[1];
 
         // Pipe through route middleware...


### PR DESCRIPTION
At the moment Lumen will only set the route resolver on an external request (through the browser). That's because the route resolver (along with the user resolver) are only set when the request instance is resolved from the container without having already been bound.

When a request is dispatched and an actual request instance is passed in then the route resolver is never set, so `$request->route()` always returns `null`.

Is there a reason the resolver is set this way when Laravel sets it once the route has been found.

I don't expect this to get merged, at least, not like this. I think it should be considered though, as it's proving quite a pain within Dingo.

I suggest the route resolver is moved to this location, and we set up a `rebinding` somewhere for the `request` instance so we can set the user resolver, much like how Laravel does it. That way *all* requests will receive the standard route/user resolvers.