### PR TITLE
Set route resolver on request when route is found

### DIFF
--- a/src/Application.php
+++ b/src/Application.php
@@ -1281,6 +1281,10 @@ class Application extends Container implements ApplicationContract, HttpKernelIn
     {
         $this->currentRoute = $routeInfo;
 
+        $this['request']->setRouteResolver(function () {
+            return $this->currentRoute;
+        });
+
         $action = $routeInfo[1];
 
         // Pipe through route middleware...


### PR DESCRIPTION
Same as #381 except for 5.1.

Sets the route resolver on requests that are fired manually through the `dispatch` method.