### PR TITLE
Added support to Illuminate/Validator update

### DIFF
--- a/resources/lang/en/validation.php
+++ b/resources/lang/en/validation.php
@@ -16,11 +16,13 @@ return [
     'accepted'             => 'The :attribute must be accepted.',
     'active_url'           => 'The :attribute is not a valid URL.',
     'after'                => 'The :attribute must be a date after :date.',
+    'after_equal'          => 'The :attribute must be a date after or equal to:date.',
     'alpha'                => 'The :attribute may only contain letters.',
     'alpha_dash'           => 'The :attribute may only contain letters, numbers, and dashes.',
     'alpha_num'            => 'The :attribute may only contain letters and numbers.',
     'array'                => 'The :attribute must be an array.',
     'before'               => 'The :attribute must be a date before :date.',
+    'before_equal'         => 'The :attribute must be a date before or equal to :date.',
     'between'              => [
         'numeric' => 'The :attribute must be between :min and :max.',
         'file'    => 'The :attribute must be between :min and :max kilobytes.',


### PR DESCRIPTION
Added support to my update of Illuminate/validation/Validator.php (https://github.com/helipillo/validation). 
Which consists in 2 new data validation types which will check if the data given is a date before/after or equal the referenced one.

Changes were:

    - Added error messages for the new validation types: before_equal & after_equal