### PR TITLE
Fix injecting Database Connection Resolver

### DIFF
--- a/src/Application.php
+++ b/src/Application.php
@@ -742,6 +742,8 @@ class Application extends Container
             'Illuminate\Contracts\Config\Repository' => 'config',
             'Illuminate\Container\Container' => 'app',
             'Illuminate\Contracts\Container\Container' => 'app',
+            'Illuminate\Database\ConnectionResolverInterface' => 'db',
+            'Illuminate\Database\DatabaseManager' => 'db',
             'Illuminate\Contracts\Encryption\Encrypter' => 'encrypter',
             'Illuminate\Contracts\Events\Dispatcher' => 'events',
             'Illuminate\Contracts\Hashing\Hasher' => 'hash',


### PR DESCRIPTION
It can be fixed through manually registering the binding in the `bootstrap/app.php`, but I think it supposed to be available as a default. Now you can type-hint `Illuminate\Database\ConnectionResolverInterface` in a Seeder class or anywhere people want.

See Issue #350, #51 
