### PR TITLE
[5.2] Fix not being to able nest group attributes

### DIFF
--- a/src/Concerns/RoutesRequests.php
+++ b/src/Concerns/RoutesRequests.php
@@ -87,11 +87,62 @@ trait RoutesRequests
             $attributes['middleware'] = explode('|', $attributes['middleware']);
         }
 
-        $this->groupAttributes = $attributes;
+        $this->groupAttributes = $this->nestAttributes($attributes);
 
         call_user_func($callback, $this);
 
         $this->groupAttributes = $parentGroupAttributes;
+    }
+
+    /**
+     * Nest the group attributes.
+     *
+     * @param  array  $attributes
+     * @return array
+     */
+    protected function nestAttributes(array $attributes)
+    {
+        $nestedAttributes = $this->groupAttributes;
+
+        foreach ($attributes as $key => $value) {
+            if (! isset($nestedAttributes[$key])) {
+                $nestedAttributes[$key] = $value;
+            } else {
+                $this->concatAttribute($key, $value, $nestedAttributes);
+            }
+        }
+
+        return $nestedAttributes;
+    }
+
+    /**
+     * Concat attributes that exist on parent group attributes.
+     *
+     * @param  string  $key
+     * @param  string  $value
+     * @param  &array  $source
+     * @return void
+     */
+    protected function concatAttribute($key, $value, &$source)
+    {
+        switch ($key) {
+            case 'namespace':
+                $source[$key] .= '\\'.$value;
+                break;
+
+            case 'prefix':
+                $source[$key] = trim($source[$key], '/').'/'.trim($value, '/');
+                break;
+
+            default:
+                if (is_array($value)) {
+                    $source[$key] = array_merge($source[$key], $value);
+                } elseif (is_string($value)) {
+                    $source[$key] .= $value;
+                } else {
+                    $source[$key] = $value;
+                }
+        }
     }
 
     /**


### PR DESCRIPTION
So the documentation points out that Lumen does support nesting group attributes, although in previous version of Lumen, I think it didn't. @taylorotwell talks about wanting to make the routes faster, so there shouldn't be no complicated route groups nesting. But now it changes?

https://lumen.laravel.com/docs/5.2/routing#route-groups

So I try to implement the nesting of group attributes, I think the problem lies on the line 90, where to preserve the `groupAttributes`, store it temporarily on the `$parentGroupAttributes` variable, but it does not take into account the "previous" parent attributes to the new attributes.

I am not sure whether my fix is the best approach though, because there are some code duplication between the newly added methods, to the `mergeGroupAttributes()` method, which actually merge the attributes into the `action` key of the `routes` information. I think it can be refactor more, but I do not want break too much code yet for now.

Issue #386 .

