### PR TITLE
Remove 'session' as supported option

### DIFF
--- a/config/auth.php
+++ b/config/auth.php
@@ -30,7 +30,7 @@ return [
     | users are actually retrieved out of your database or other storage
     | mechanisms used by this application to persist your user's data.
     |
-    | Supported: "session", "token"
+    | Supported: "token"
     |
     */
 


### PR DESCRIPTION
Error: `Class session.store does not exist` trying to authenticate with the `session` driver.

Note: `SessionGuard` is the only Guard with a `onceBasic` method

[Related Issue](https://github.com/laravel/lumen-framework/issues/388)