### PR TITLE
[5.2] Default $commands in Console Kernel

### DIFF
--- a/src/Console/Kernel.php
+++ b/src/Console/Kernel.php
@@ -28,6 +28,13 @@ class Kernel implements KernelContract
     protected $artisan;
 
     /**
+     * The Artisan commands provided by the application.
+     *
+     * @var array
+     */
+    protected $commands = [];
+
+    /**
      * Create a new console kernel instance.
      *
      * @param  \Laravel\Lumen\Application  $app


### PR DESCRIPTION
I'm whipping up a simple app where I won't need to extend the console in any way, and usually when there is a feature I won't be using, I rip out the folders to clean up the directory structure.

However, removing the `app/Console/Kernel.php` file (+ changing the container binding in the bootstrap file) currency breaks the Artisan CLI with this error:

    Undefined property: Laravel\Lumen\Console\Kernel::$commands

This PR simply adds a default `$commands = []` property on the Console Kernel class. As a side note, the Console Kernel in the Laravel Framework _does_ contain a default `$commands` property.

Also, I feel that it _should_ be an option to use `Laravel\Lumen\Console\Kernel` without first extending it, as it is not abstract.
