### PR TITLE
[5.2] Allow middleware to replace route info and route parameters

### DIFF
--- a/src/Concerns/RoutesRequests.php
+++ b/src/Concerns/RoutesRequests.php
@@ -470,8 +470,8 @@ trait RoutesRequests
         if (isset($action['middleware'])) {
             $middleware = $this->gatherMiddlewareClassNames($action['middleware']);
 
-            return $this->prepareResponse($this->sendThroughPipeline($middleware, function () use ($routeInfo) {
-                return $this->callActionOnArrayBasedRoute($routeInfo);
+            return $this->prepareResponse($this->sendThroughPipeline($middleware, function () {
+                return $this->callActionOnArrayBasedRoute($this['request']->route());
             }));
         }
 


### PR DESCRIPTION
This PR resolves route from request's routeResolver after piping it through middleware. It allows for middleware to override array based routeInfo by setting route resolver on request instance.

For example it makes possible to use implicit route model binding middleware like this (code taken from Lumen's big brother and adapted for array based route): [SubstituteImplicitBindings.php](https://gist.github.com/sw-double/bdc8285b61be5a8e064d)