### PR TITLE
Enchancement: native validation json requests(application/json)

### DIFF
--- a/src/Routing/ProvidesConvenienceMethods.php
+++ b/src/Routing/ProvidesConvenienceMethods.php
@@ -58,7 +58,9 @@ trait ProvidesConvenienceMethods
      */
     public function validate(Request $request, array $rules, array $messages = [], array $customAttributes = [])
     {
-        $validator = $this->getValidationFactory()->make($request->all(), $rules, $messages, $customAttributes);
+        $data = $request->isJson() ? $request->json()->all() : $request->all();
+
+        $validator = $this->getValidationFactory()->make($data, $rules, $messages, $customAttributes);
 
         if ($validator->fails()) {
             $this->throwValidationException($request, $validator);


### PR DESCRIPTION
… over standard func validate().

This PR is modify incoming data from request in validate() function by using $request->json->all() in case when $request->isJson() true.

This PR allow using equal validate syntax for json && x-www-form-urlencoded requests. It may be usefull for mixed api, migration from x-www-form-urlencoded to json api and vice versa. 

### Use case of PR:
On this moment if we want validate json request (content-type:application/json),we need do something like this (example):
```php
$InputData = array('username' =>Input::json('username'),
                    'password'=>Input::json('password'));

$validation = Validator::make( $InputData,array('username'=>'required|email','password'=>'required'));
```
In case of forms request (content-type:application/x-www-form-urlencoded) we can use default&clean syntax:
```php
$this->validate($request, [
        'title' => 'required|unique:posts|max:255',
        'body' => 'required',
    ]);
```

This PR allow use of 
```php
$this->validate($request, [
        'title' => 'required|unique:posts|max:255',
        'body' => 'required',
    ]);
```
on application/json request using built-in functions.