### PR TITLE
addRoute now accepts multiple methods

### DIFF
--- a/src/Concerns/RoutesRequests.php
+++ b/src/Concerns/RoutesRequests.php
@@ -181,9 +181,9 @@ trait RoutesRequests
     /**
      * Add a route to the collection.
      *
-     * @param  string  $method
-     * @param  string  $uri
-     * @param  mixed  $action
+     * @param  array|string  $method
+     * @param  string        $uri
+     * @param  mixed         $action
      */
     public function addRoute($method, $uri, $action)
     {
@@ -207,7 +207,13 @@ trait RoutesRequests
             $this->namedRoutes[$action['as']] = $uri;
         }
 
-        $this->routes[$method.$uri] = ['method' => $method, 'uri' => $uri, 'action' => $action];
+        if (is_array($method)) {
+            foreach ($method as $verb) {
+                $this->routes[$verb . $uri] = ['method' => $verb, 'uri' => $uri, 'action' => $action];
+            }
+        } else {
+            $this->routes[$method . $uri] = ['method' => $method, 'uri' => $uri, 'action' => $action];
+        }
     }
 
     /**

--- a/tests/FullApplicationTest.php
+++ b/tests/FullApplicationTest.php
@@ -25,6 +25,25 @@ class FullApplicationTest extends PHPUnit_Framework_TestCase
         $this->assertEquals('Hello World', $response->getContent());
     }
 
+    public function testAddRouteMultipleMethodRequest()
+    {
+        $app = new Application;
+
+        $app->addRoute(['GET', 'POST'], '/', function() {
+            return response('Hello World');
+        });
+
+        $response = $app->handle(Request::create('/', 'GET'));
+
+        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertEquals('Hello World', $response->getContent());
+
+        $response = $app->handle(Request::create('/', 'POST'));
+
+        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertEquals('Hello World', $response->getContent());
+    }
+
     public function testRequestWithoutSymfonyClass()
     {
         $app = new Application;


### PR DESCRIPTION
## Use case

Instead of having to do:
```
$app->options('/', 'Controller@Action');
$app->get('/', 'Controller@Action');
```

Can just do:
```
$app->addRoute(['GET', 'OPTIONS'], '/', 'Controller@Action');
```