### PR TITLE
[5.2] Fix undefined variable error on array route

### DIFF
--- a/src/Concerns/RoutesRequests.php
+++ b/src/Concerns/RoutesRequests.php
@@ -504,15 +504,14 @@ trait RoutesRequests
         foreach ($action as $value) {
             if ($value instanceof Closure) {
                 $closure = $value->bindTo(new RoutingClosure);
-                break;
+                try {
+                    return $this->prepareResponse($this->call($closure, $routeInfo[2]));
+                } catch (HttpResponseException $e) {
+                    return $e->getResponse();
+                }
             }
         }
-
-        try {
-            return $this->prepareResponse($this->call($closure, $routeInfo[2]));
-        } catch (HttpResponseException $e) {
-            return $e->getResponse();
-        }
+        throw new NotFoundHttpException;
     }
 
     /**


### PR DESCRIPTION
if no uses entry and clousure supplied, then undefined variable error occured.
(eg. misstype uses => use )
 
in this case it should throw Exception like NotFoundHttpException