### PR TITLE
[5.2] Clear facades before bootstrapping the app

### DIFF
--- a/src/Testing/TestCase.php
+++ b/src/Testing/TestCase.php
@@ -51,9 +51,9 @@ abstract class TestCase extends PHPUnit_Framework_TestCase
     {
         putenv('APP_ENV=testing');
 
-        $this->app = $this->createApplication();
-
         Facade::clearResolvedInstances();
+
+        $this->app = $this->createApplication();
     }
 
     /**


### PR DESCRIPTION
If facades are not cleared first service providers using facades will boot with the old instance.

This is really hard to test without the concrete implemention of TestCase in Laravel/Lumen.  You can reproduce using these steps in a fresh Lumen install:

Add this to `AppServiceProvider.php`:

```php
Validator::extend('rad', function ($attribute, $value, $parameters) {
        return str_contains($value, 'rad');
});
```

Add this to `routes.php`:

```php
$app->post('/', function (Illuminate\Http\Request $request) {
    $this->validate($request, [
        'mood' => 'rad'
    ]);

    return json_encode(['hello' => 'world']);
});
````

Uncomment these lines in `bootstrap/app.php:

``php
$app->register(App\Providers\AppServiceProvider::class);
$app->withFacades();
``

Add this test to `ExampleTest.php`:

```php
public function testValidResponse()
{
    $this
        ->json('POST', '/', ['mood' => 'radical'])
        ->seeJsonEquals(['hello' => 'world']);
}
```

Expected Results:

The test should pass.

Actual Results

The test fails with an error 'method validateRad does not exist` (which actually becomes an invalid arg error because it can't be json decoded).

Closes #357