### PR TITLE
[5.2] Add seeHeader method to MakesHttpRequests trait

### DIFF
--- a/src/Testing/Concerns/MakesHttpRequests.php
+++ b/src/Testing/Concerns/MakesHttpRequests.php
@@ -355,6 +355,29 @@ trait MakesHttpRequests
     }
 
     /**
+     * Asserts that the response contains the given header and equals the optional value.
+     *
+     * @param  string  $headerName
+     * @param  mixed  $value
+     * @return $this
+     */
+    protected function seeHeader($headerName, $value = null)
+    {
+        $headers = $this->response->headers;
+
+        $this->assertTrue($headers->has($headerName), "Header [{$headerName}] not present on response.");
+
+        if (! is_null($value)) {
+            $this->assertEquals(
+                $headers->get($headerName), $value,
+                "Header [{$headerName}] was found, but value [{$headers->get($headerName)}] does not match [{$value}]."
+            );
+        }
+
+        return $this;
+    }
+
+    /**
      * Transform headers array to array of $_SERVER vars with HTTP_* format.
      *
      * @param  array  $headers


### PR DESCRIPTION
This method is important in lumen to be able to test that headers like
`Access-Control-Allow-Origin` are present on the response.

The implementation is copied directly from Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php

https://github.com/laravel/framework/blob/5.2/src/Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php#L402

