### PR TITLE
Consistent spacing in config files

### DIFF
--- a/config/app.php
+++ b/config/app.php
@@ -27,7 +27,9 @@ return [
     | to any of the locales which will be supported by the application.
     |
     */
+
     'locale' => env('APP_LOCALE', 'en'),
+
     /*
     |--------------------------------------------------------------------------
     | Application Fallback Locale
@@ -38,6 +40,7 @@ return [
     | the language folders that are provided through your application.
     |
     */
+    
     'fallback_locale' => env('APP_FALLBACK_LOCALE', 'en'),
 
 ];


### PR DESCRIPTION
Every other file has one line break between them. 

But the locale configuration doesn't. 