### PR TITLE
[5.2] Fixed incorrect logging error suppression

### DIFF
--- a/src/Exceptions/Handler.php
+++ b/src/Exceptions/Handler.php
@@ -37,10 +37,12 @@ class Handler implements ExceptionHandler
         }
 
         try {
-            app('Psr\Log\LoggerInterface')->error($e);
+            $logger = app('Psr\Log\LoggerInterface');
         } catch (Exception $ex) {
             throw $e; // throw the original exception
         }
+
+        $logger->error($e);
     }
 
     /**


### PR DESCRIPTION
We don't want to suppress errors like when the file permissions are incorrect on the storage folder, for example.