### PR TITLE
[5.3] Fixed service provider registration

### DIFF
--- a/src/Application.php
+++ b/src/Application.php
@@ -168,8 +168,13 @@ class Application extends Container
 
         $this->loadedProviders[$providerName] = true;
 
-        $provider->register();
-        $provider->boot();
+        if (method_exists($provider, 'register')) {
+            $provider->register();
+        }
+
+        if (method_exists($provider, 'boot')) {
+            return $this->call([$provider, 'boot']);
+        }
     }
 
     /**


### PR DESCRIPTION
Needed after we deleted the `__call` fallback in the main laravel repository.

This is now in sync with what the main framework does to setup providers.