### PR TITLE
[5.3] Allow user to register Facades within the `withFacades` method.

### DIFF
--- a/src/Application.php
+++ b/src/Application.php
@@ -651,12 +651,12 @@ class Application extends Container
             'Illuminate\Support\Facades\URL' => 'URL',
             'Illuminate\Support\Facades\Validator' => 'Validator',
         ];
-        
+
         if (! static::$aliasesRegistered) {
             static::$aliasesRegistered = true;
 
             $merged = array_merge($defaults, $userAliases);
-            
+
             foreach ($merged as $original => $alias) {
                 class_alias($original, $alias);
             }

--- a/src/Application.php
+++ b/src/Application.php
@@ -619,37 +619,47 @@ class Application extends Container
      * Register the facades for the application.
      *
      * @param  bool  $aliases
+     * @param  array $userAliases
      * @return void
      */
-    public function withFacades($aliases = true)
+    public function withFacades($aliases = true, $userAliases = [])
     {
         Facade::setFacadeApplication($this);
 
         if ($aliases) {
-            $this->withAliases();
+            $this->withAliases($userAliases);
         }
     }
 
     /**
      * Register the aliases for the application.
      *
+     * @param array $userAliases
      * @return void
      */
-    public function withAliases()
+    public function withAliases($userAliases = [])
     {
+        $defaults = [
+            'Illuminate\Support\Facades\Auth' => 'Auth',
+            'Illuminate\Support\Facades\Cache' => 'Cache',
+            'Illuminate\Support\Facades\DB' => 'DB',
+            'Illuminate\Support\Facades\Event' => 'Event',
+            'Illuminate\Support\Facades\Gate' => 'Gate',
+            'Illuminate\Support\Facades\Log' => 'Log',
+            'Illuminate\Support\Facades\Queue' => 'Queue',
+            'Illuminate\Support\Facades\Schema' => 'Schema',
+            'Illuminate\Support\Facades\URL' => 'URL',
+            'Illuminate\Support\Facades\Validator' => 'Validator',
+        ];
+        
         if (! static::$aliasesRegistered) {
             static::$aliasesRegistered = true;
 
-            class_alias('Illuminate\Support\Facades\Auth', 'Auth');
-            class_alias('Illuminate\Support\Facades\Cache', 'Cache');
-            class_alias('Illuminate\Support\Facades\DB', 'DB');
-            class_alias('Illuminate\Support\Facades\Event', 'Event');
-            class_alias('Illuminate\Support\Facades\Gate', 'Gate');
-            class_alias('Illuminate\Support\Facades\Log', 'Log');
-            class_alias('Illuminate\Support\Facades\Queue', 'Queue');
-            class_alias('Illuminate\Support\Facades\Schema', 'Schema');
-            class_alias('Illuminate\Support\Facades\URL', 'URL');
-            class_alias('Illuminate\Support\Facades\Validator', 'Validator');
+            $merged = array_merge($defaults, $userAliases);
+            
+            foreach ($merged as $original => $alias) {
+                class_alias($original, $alias);
+            }
         }
     }
 

--- a/tests/FullApplicationTest.php
+++ b/tests/FullApplicationTest.php
@@ -515,11 +515,11 @@ class FullApplicationTest extends PHPUnit_Framework_TestCase
 
         $this->assertInstanceOf('Illuminate\Contracts\Validation\Factory', $validator);
     }
-    
+
     public function testCanMergeUserProvidedFacadesWithDefaultOnes()
     {
         $app = new Application();
-        
+
         $aliases = [
             UserFacade::class => 'Foo',
         ];

--- a/tests/FullApplicationTest.php
+++ b/tests/FullApplicationTest.php
@@ -521,11 +521,11 @@ class FullApplicationTest extends PHPUnit_Framework_TestCase
         $app = new Application();
         
         $aliases = [
-            UserFacade::class => 'Foo'
+            UserFacade::class => 'Foo',
         ];
-        
+
         $app->withFacades(true, $aliases);
-        
+
         $this->assertTrue(class_exists('Foo'));
     }
 }

--- a/tests/FullApplicationTest.php
+++ b/tests/FullApplicationTest.php
@@ -515,6 +515,19 @@ class FullApplicationTest extends PHPUnit_Framework_TestCase
 
         $this->assertInstanceOf('Illuminate\Contracts\Validation\Factory', $validator);
     }
+    
+    public function testCanMergeUserProvidedFacadesWithDefaultOnes()
+    {
+        $app = new Application();
+        
+        $aliases = [
+            UserFacade::class => 'Foo'
+        ];
+        
+        $app->withFacades(true, $aliases);
+        
+        $this->assertTrue(class_exists('Foo'));
+    }
 }
 
 class LumenTestService
@@ -587,4 +600,8 @@ class LumenTestAction
     {
         return $id;
     }
+}
+
+class UserFacade
+{
 }


### PR DESCRIPTION
This is in reference to #432.

If we want to add a new Facade to a Lumen application we have to manually add `class_alias` in the `bootstrap/app.php` file. However this might cause issues when using PHPUnit since it will include `bootstrap/app.php` more than once. This will result in an error since it is trying to register the `class_alias` again.

> Cannot declare class ExampleAlias, because the name is already in use

One way to fix that is to wrap each `class_alias` in a `if (!class_exists('Foo', 'Bar'))`. If I need to register multiple Facades this will lead to a lot of code duplication and clutter in my `bootstrap/app.php`.

For the default Facades Lumen already checks if the Facades have been registered yet. So my proposed fix is to add a second, optional parameter to the `withFacades` function where a user can provide an array of class aliases to register alongside the default Facades. This would mean, that the user Facades will be included in the above mentioned check.

Before
```php
// bootstrap/app.php

$app->withFacades();

if (!class_exists('Foo')) {
    class_alias('My\Class', 'Foo');
}

if (!class_exists('Bar')) {
    class_alias('My\Other\Class', 'Bar');
}
```

After 
```php
// bootstrap/app.php

$app->withFacades(true, [
    'My\Class' => 'Foo',
    'My\Other\Class' => 'Bar'
]);
```
