### PR TITLE
[5.2] Adds getNamespace to Application

### DIFF
--- a/src/Application.php
+++ b/src/Application.php
@@ -3,6 +3,7 @@
 namespace Laravel\Lumen;
 
 use Monolog\Logger;
+use RuntimeException;
 use Illuminate\Support\Str;
 use Illuminate\Http\Request;
 use Illuminate\Support\Composer;
@@ -734,6 +735,32 @@ class Application extends Container
         $this->register('Illuminate\Database\MigrationServiceProvider');
         $this->register('Illuminate\Database\SeedServiceProvider');
         $this->register('Illuminate\Queue\ConsoleServiceProvider');
+    }
+
+    /**
+     * Get the application namespace.
+     *
+     * @return string
+     *
+     * @throws \RuntimeException
+     */
+    public function getNamespace()
+    {
+        if (! is_null($this->namespace)) {
+            return $this->namespace;
+        }
+
+        $composer = json_decode(file_get_contents(base_path('composer.json')), true);
+
+        foreach ((array) data_get($composer, 'autoload.psr-4') as $namespace => $path) {
+            foreach ((array) $path as $pathChoice) {
+                if (realpath(app()->path()) == realpath(base_path().'/'.$pathChoice)) {
+                    return $this->namespace = $namespace;
+                }
+            }
+        }
+
+        throw new RuntimeException('Unable to detect application namespace.');
     }
 
     /**

--- a/tests/FullApplicationTest.php
+++ b/tests/FullApplicationTest.php
@@ -428,6 +428,13 @@ class FullApplicationTest extends PHPUnit_Framework_TestCase
         $this->assertTrue($app->environment(['production']));
     }
 
+    public function testNamespaceDetection()
+    {
+        $app = new Application;
+        $this->setExpectedException('RuntimeException');
+        $app->getNamespace();
+    }
+
     public function testRunningUnitTestsDetection()
     {
         $app = new Application;


### PR DESCRIPTION
The Illuminate\Console\AppNamespaceDetectorTrait throws an error when attempting to call the getNamespace method on the Container instance. Pulled this from `Illuminate\Foundation\Application` and added it.  