### PR TITLE
[5.2] Update MakesHttpRequests.php to have correct seeHeader test output.

### DIFF
--- a/src/Testing/Concerns/MakesHttpRequests.php
+++ b/src/Testing/Concerns/MakesHttpRequests.php
@@ -431,7 +431,7 @@ trait MakesHttpRequests
 
         if (! is_null($value)) {
             $this->assertEquals(
-                $headers->get($headerName), $value,
+                $value, $headers->get($headerName),
                 "Header [{$headerName}] was found, but value [{$headers->get($headerName)}] does not match [{$value}]."
             );
         }


### PR DESCRIPTION
The method seeHeader in MakesHttpRequests should display the correct "Expected" and "Actual" test output. Right now, it thinks that what comes back in the request is the expected header.