### PR TITLE
Revert "[5.2] Update MakesHttpRequests.php to have correct seeHeader test output."

### DIFF
--- a/src/Testing/Concerns/MakesHttpRequests.php
+++ b/src/Testing/Concerns/MakesHttpRequests.php
@@ -431,7 +431,7 @@ trait MakesHttpRequests
 
         if (! is_null($value)) {
             $this->assertEquals(
-                $value, $headers->get($headerName),
+                $headers->get($headerName), $value,
                 "Header [{$headerName}] was found, but value [{$headers->get($headerName)}] does not match [{$value}]."
             );
         }


### PR DESCRIPTION
This breaks the assertResponseStatus method.