### PR TITLE
route() allow pass parameters as indexed array

### DIFF
--- a/src/Routing/UrlGenerator.php
+++ b/src/Routing/UrlGenerator.php
@@ -219,8 +219,14 @@ class UrlGenerator
 
         $parameters = $this->formatParametersForUrl($parameters);
 
+        $index = -1;
+
         $uri = preg_replace_callback('/\{(.*?)(:.*?)?(\{[0-9,]+\})?\}/', function ($m) use (&$parameters) {
-            return isset($parameters[$m[1]]) ? array_pull($parameters, $m[1]) : $m[0];
+            $index++;
+            
+            return isset($parameters[$m[1]])
+                ? array_pull($parameters, $m[1])
+                : (isset($parameters[$index]) ? array_pull($parameters, $index) : $m[0]);
         }, $uri);
 
         $uri = $this->to($uri, []);


### PR DESCRIPTION
allow $parameters to be one value, indexed array or assoc array,
and set them for wildcards by (index or name),

before it had to be passed like :
route('foo', ['wildcard' => 'value']);

but now you can do the following :
route('foo', 'value');
route('foo', ['value']);
route('foo', ['wildcard' => 'value']);
route('foo', ['value1', 'value2']);
route('foo', ['wildcard2' => 'value2', 'wildcard1' => 'value1']);