### PR TITLE
Middleware bug fixes

### DIFF
--- a/src/Concerns/RoutesRequests.php
+++ b/src/Concerns/RoutesRequests.php
@@ -358,6 +358,10 @@ trait RoutesRequests
      */
     protected function callTerminableMiddleware($response)
     {
+        if ($this->shouldSkipMiddleware()) {
+            return;
+        }
+
         $response = $this->prepareResponse($response);
 
         foreach ($this->middleware as $middleware) {
@@ -629,10 +633,7 @@ trait RoutesRequests
      */
     protected function sendThroughPipeline(array $middleware, Closure $then)
     {
-        $shouldSkipMiddleware = $this->bound('middleware.disable') &&
-                                        $this->make('middleware.disable') === true;
-
-        if (count($middleware) > 0 && ! $shouldSkipMiddleware) {
+        if (count($middleware) > 0 && ! $this->shouldSkipMiddleware()) {
             return (new Pipeline($this))
                 ->send($this->make('request'))
                 ->through($middleware)
@@ -685,6 +686,16 @@ trait RoutesRequests
         $query = isset($_SERVER['QUERY_STRING']) ? $_SERVER['QUERY_STRING'] : '';
 
         return '/'.trim(str_replace('?'.$query, '', $_SERVER['REQUEST_URI']), '/');
+    }
+
+    /**
+     * Should middleware be skipped for this request?
+     *
+     * @return bool
+     */
+    protected function shouldSkipMiddleware()
+    {
+        return $this->bound('middleware.disable') && $this->make('middleware.disable') === true;
     }
 
     /**

--- a/src/Concerns/RoutesRequests.php
+++ b/src/Concerns/RoutesRequests.php
@@ -320,7 +320,13 @@ trait RoutesRequests
      */
     public function handle(SymfonyRequest $request, $type = HttpKernelInterface::MASTER_REQUEST, $catch = true)
     {
-        return $this->dispatch($request);
+        $response = $this->dispatch($request);
+
+        if (count($this->middleware) > 0) {
+            $this->callTerminableMiddleware($response);
+        }
+
+        return $response;
     }
 
     /**
@@ -359,7 +365,7 @@ trait RoutesRequests
                 continue;
             }
 
-            $instance = $this->make($middleware);
+            $instance = $this->make(explode(':', $middleware)[0]);
 
             if (method_exists($instance, 'terminate')) {
                 $instance->terminate($this->make('request'), $response);

--- a/tests/FullApplicationTest.php
+++ b/tests/FullApplicationTest.php
@@ -229,6 +229,23 @@ class FullApplicationTest extends PHPUnit_Framework_TestCase
         $this->assertEquals('TERMINATED', $response->getContent());
     }
 
+    public function testTerminateWithMiddlewareDisabled()
+    {
+        $app = new Application;
+
+        $app->middleware(['LumenTestTerminateMiddleware']);
+        $app->instance('middleware.disable', true);
+
+        $app->get('/', function () {
+            return response('Hello World');
+        });
+
+        $response = $app->handle(Request::create('/', 'GET'));
+
+        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertEquals('Hello World', $response->getContent());
+    }
+
     public function testNotFoundResponse()
     {
         $app = new Application;

--- a/tests/FullApplicationTest.php
+++ b/tests/FullApplicationTest.php
@@ -213,6 +213,22 @@ class FullApplicationTest extends PHPUnit_Framework_TestCase
         $this->assertEquals('Hello World', $response->getContent());
     }
 
+    public function testTerminableGlobalMiddleware()
+    {
+        $app = new Application;
+
+        $app->middleware(['LumenTestTerminateMiddleware']);
+
+        $app->get('/', function () {
+            return response('Hello World');
+        });
+
+        $response = $app->handle(Request::create('/', 'GET'));
+
+        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertEquals('TERMINATED', $response->getContent());
+    }
+
     public function testNotFoundResponse()
     {
         $app = new Application;
@@ -573,5 +589,18 @@ class LumenTestParameterizedMiddleware
     public function handle($request, $next, $parameter1, $parameter2)
     {
         return response("Middleware - $parameter1 - $parameter2");
+    }
+}
+
+class LumenTestTerminateMiddleware
+{
+    public function handle($request, $next)
+    {
+        return $next($request);
+    }
+
+    public function terminate($request, Illuminate\Http\Response $response)
+    {
+        $response->setContent('TERMINATED');
     }
 }


### PR DESCRIPTION
**Issue 1**

The bug occurs when global middleware is assigned with parameters:

`$app->middleware(['LumenTestParameterizedMiddleware:foo,bar']);`

In `$app->run()` after the response is send, when `callTerminableMiddleware()` runs it will throw an exception because the full string with parameters is passed to `make()`, so you'll get:

> ReflectionException: Class LumenTestParameterizedMiddleware:foo,bar does not exist

So the simple fix for that is to trim off any parameters. However, there's already a test case for this that has been passing: `\FullApplicationTest::testGlobalMiddlewareParameters()`. This highlighted the fact that the `handle()` method used for testing is not a true representation of `run()`, because it never checks for and attempts to run middleware terminate methods.

Now `handle()` too will run `callTerminableMiddleware()` if global middleware exists, so testing is more accurate, with the added benefit that now terminate methods will be fired from tests.

**Issue 2**

Terminate middleware is called even if `middleware.disable` is true.