### PR TITLE
Message on NotFoundHttpException and MethodNotAllowedHttpException

### DIFF
--- a/src/Concerns/RoutesRequests.php
+++ b/src/Concerns/RoutesRequests.php
@@ -395,7 +395,9 @@ trait RoutesRequests
                 }
 
                 return $this->handleDispatcherResponse(
-                    $this->createDispatcher()->dispatch($method, $pathInfo)
+                    $this->createDispatcher()->dispatch($method, $pathInfo),
+                    $method,
+                    $pathInfo
                 );
             });
         } catch (Exception $e) {
@@ -452,16 +454,26 @@ trait RoutesRequests
      * Handle the response from the FastRoute dispatcher.
      *
      * @param  array  $routeInfo
+     * @param  string $method
+     * @param  string $pathInfo
      * @return mixed
      */
-    protected function handleDispatcherResponse($routeInfo)
+    protected function handleDispatcherResponse($routeInfo, $method, $pathInfo)
     {
         switch ($routeInfo[0]) {
             case Dispatcher::NOT_FOUND:
-                throw new NotFoundHttpException;
+                throw new NotFoundHttpException(sprintf(
+                    'Route "%s %s" is not found',
+                    $method,
+                    $pathInfo
+                ));
 
             case Dispatcher::METHOD_NOT_ALLOWED:
-                throw new MethodNotAllowedHttpException($routeInfo[1]);
+                throw new MethodNotAllowedHttpException($routeInfo[1], sprintf(
+                    'Method "%s %s" is not allowed',
+                    $method,
+                    $pathInfo
+                ));
 
             case Dispatcher::FOUND:
                 return $this->handleFoundRoute($routeInfo);


### PR DESCRIPTION
## Overview

This PR add message when NotFoundHttpException and MethodNotAllowedHttpException exceptions are thrown.

## Problem

I'm creating an application using Lumen and trying to develop using [Programming by Wishful Thinking](http://sam-serpoosh.github.io/wishful-thinking/) approach which also involving TDD. Problem comes when I started to create non-existent route which part of my wishful and run the unit test via phpunit.

The error message did not tell me which was causing the problem because:
1. Lumen convert all errors into HTTP response even when called from CLI.
2. Even when I throw the error manually to overcome issue number 1 by editing app/Exceptions/Handler.php it still gives me no error message about what was wrong.

Here's my app/Exceptions/Handler.php
```
    /**
     * Render an exception into an HTTP response.
     *
     * @param  \Illuminate\Http\Request  $request
     * @param  \Exception  $e
     * @return \Illuminate\Http\Response
     */
    public function render($request, Exception $e)
    {
        if (env('APP_DEBUG')) {
            $error = sprintf("%s\nFile: %s\n (Line: %s)\nCall Stack:\n%s",
                            $e->getMessage(),
                            $e->getFile(),
                            $e->getLine(),
                            $e->getTraceAsString());
            throw new Exception($error, $e->getCode());
        }

        if ($request->isJson()) {
            return response()->json([
                'code' => $e->getCode(),
                'status' => 'error',
                'message' => $e->getMessage(),
                'data' => $e->getTraceAsString()
            ]);
            return response()->json($response);
        }

        return parent::render($request, $e);
    }
```

## Solution

Throw more meaningful message when non existent route or not allowed method, so it is easier to debug when using TDD on CLI. 