### PR TITLE
[5.3] Allows the Error Context to be set within the Handler

### DIFF
--- a/src/Exceptions/Handler.php
+++ b/src/Exceptions/Handler.php
@@ -28,10 +28,10 @@ class Handler implements ExceptionHandler
      * Report or log an exception.
      *
      * @param  \Exception  $e
-     * @param  Array       $context
+     * @param  array       $context
      * @return void
      */
-    public function report(Exception $e, Array $context = [])
+    public function report(Exception $e, array $context = [])
     {
         if ($this->shouldntReport($e)) {
             return;

--- a/src/Exceptions/Handler.php
+++ b/src/Exceptions/Handler.php
@@ -28,9 +28,10 @@ class Handler implements ExceptionHandler
      * Report or log an exception.
      *
      * @param  \Exception  $e
+     * @param  Array       $context
      * @return void
      */
-    public function report(Exception $e)
+    public function report(Exception $e, Array $context = [])
     {
         if ($this->shouldntReport($e)) {
             return;
@@ -42,7 +43,7 @@ class Handler implements ExceptionHandler
             throw $e; // throw the original exception
         }
 
-        $logger->error($e);
+        $logger->error($e, $context);
     }
 
     /**


### PR DESCRIPTION
Optional context parameter is extremely useful for third party services like Rollbar which allows developers to define the User context of an error, for example.