### PR TITLE
Fix loading broadcasting component via event dispatcher

### DIFF
--- a/src/Application.php
+++ b/src/Application.php
@@ -239,11 +239,10 @@ class Application extends Container
     protected function registerBroadcastingBindings()
     {
         $this->singleton('Illuminate\Contracts\Broadcasting\Broadcaster', function () {
-            $this->configure('broadcasting');
-
-            $this->register('Illuminate\Broadcasting\BroadcastServiceProvider');
-
-            return $this->make('Illuminate\Contracts\Broadcasting\Broadcaster');
+            return $this->loadComponent('broadcasting', 'Illuminate\Broadcasting\BroadcastServiceProvider', 'Illuminate\Contracts\Broadcasting\Broadcaster');
+        });
+        $this->singleton('Illuminate\Contracts\Broadcasting\Factory', function () {
+            return $this->loadComponent('broadcasting', 'Illuminate\Broadcasting\BroadcastServiceProvider', 'Illuminate\Contracts\Broadcasting\Factory');
         });
     }
 
@@ -844,6 +843,7 @@ class Application extends Container
         'Illuminate\Contracts\Auth\Guard' => 'registerAuthBindings',
         'Illuminate\Contracts\Auth\Access\Gate' => 'registerAuthBindings',
         'Illuminate\Contracts\Broadcasting\Broadcaster' => 'registerBroadcastingBindings',
+        'Illuminate\Contracts\Broadcasting\Factory' => 'registerBroadcastingBindings',
         'Illuminate\Contracts\Bus\Dispatcher' => 'registerBusBindings',
         'cache' => 'registerCacheBindings',
         'cache.store' => 'registerCacheBindings',


### PR DESCRIPTION
Which could lead to difficult to troubleshoot Segmentation faults when upgrading from 5.2, or if you added the BroadcastServiceProvider yourself to `bootstrap/app.php`. This could also be resolved by changing how the event dispatcher fires broadcasting events, but since this is a Lumen specific error, it seems better here.

Solves issue: https://github.com/laravel/lumen-framework/issues/500

Excuse my newness to open source. I hoped I haven't missed something obvious I should be doing.