### PR TITLE
Makes nested groups inherit previous groups attributes

### DIFF
--- a/src/Concerns/RoutesRequests.php
+++ b/src/Concerns/RoutesRequests.php
@@ -129,7 +129,7 @@ trait RoutesRequests
             $new['as'] = $old['as'].(isset($new['as']) ? '.'.$new['as'] : '');
         }
 
-        if (isset($old['suffix']) && !isset($new['suffix'])) {
+        if (isset($old['suffix']) && ! isset($new['suffix'])) {
             $new['suffix'] = $old['suffix'];
         }
 
@@ -137,7 +137,7 @@ trait RoutesRequests
     }
 
     /**
-     * Merge the given group attributes with the last added group
+     * Merge the given group attributes with the last added group.
      *
      * @param  array $new
      * @return array
@@ -164,7 +164,6 @@ trait RoutesRequests
 
         return isset($old['namespace']) ? $old['namespace'] : null;
     }
-
 
     /**
      * Format the prefix for the new group attributes.
@@ -352,9 +351,9 @@ trait RoutesRequests
      */
     protected function mergeGroupAttributes(array $action, array $attributes)
     {
-        $namespace  = isset($attributes['namespace'])   ? $attributes['namespace']  : null;
-        $middleware = isset($attributes['middleware'])  ? $attributes['middleware'] : null;
-        $as         = isset($attributes['as'])          ? $attributes['as']         : null;
+        $namespace = isset($attributes['namespace']) ? $attributes['namespace'] : null;
+        $middleware = isset($attributes['middleware']) ? $attributes['middleware'] : null;
+        $as = isset($attributes['as']) ? $attributes['as'] : null;
 
         return $this->mergeNamespaceGroup(
             $this->mergeMiddlewareGroup(
@@ -401,7 +400,7 @@ trait RoutesRequests
     }
 
     /**
-     * Merge the as group into the action
+     * Merge the as group into the action.
      * 
      * @param  array $action
      * @param  string $as
@@ -409,9 +408,9 @@ trait RoutesRequests
      */
     protected function mergeAsGroup(array $action, $as = null)
     {
-        if (isset($as) && !empty($as)) {
+        if (isset($as) && ! empty($as)) {
             if (isset($action['as'])) {
-                $action['as'] = $as . ".". $action['as'];
+                $action['as'] = $as.'.'.$action['as'];
             } else {
                 $action['as'] = $as;
             }

--- a/src/Concerns/RoutesRequests.php
+++ b/src/Concerns/RoutesRequests.php
@@ -401,7 +401,7 @@ trait RoutesRequests
 
     /**
      * Merge the as group into the action.
-     * 
+     *
      * @param  array $action
      * @param  string $as
      * @return array

--- a/tests/FullApplicationTest.php
+++ b/tests/FullApplicationTest.php
@@ -573,10 +573,10 @@ class FullApplicationTest extends PHPUnit_Framework_TestCase
     {
         $app = new Application();
 
-        $app->group(['middleware' => 'middleware1'], function($app) {
-           $app->group(['middleware' => 'middleware2|middleware3'], function($app) {
-               $app->get('test', "LumenTestController@show");
-           });
+        $app->group(['middleware' => 'middleware1'], function ($app) {
+            $app->group(['middleware' => 'middleware2|middleware3'], function ($app) {
+                $app->get('test', 'LumenTestController@show');
+            });
         });
 
         $route = $app->getRoutes()['GET/test'];
@@ -584,7 +584,7 @@ class FullApplicationTest extends PHPUnit_Framework_TestCase
         $this->assertEquals([
             'middleware1',
             'middleware2',
-            'middleware3'
+            'middleware3',
         ], $route['action']['middleware']);
     }
 
@@ -592,16 +592,15 @@ class FullApplicationTest extends PHPUnit_Framework_TestCase
     {
         $app = new Application();
 
-        $app->group(['namespace' => 'Hello'], function($app) {
-
-            $app->group(['namespace' => 'World'], function($app) {
-                $app->get('/world', "Class@method");
+        $app->group(['namespace' => 'Hello'], function ($app) {
+            $app->group(['namespace' => 'World'], function ($app) {
+                $app->get('/world', 'Class@method');
             });
         });
 
         $routes = $app->getRoutes();
 
-        $route = $routes["GET/world"];
+        $route = $routes['GET/world'];
 
         $this->assertEquals('Hello\\World\\Class@method', $route['action']['uses']);
     }
@@ -610,32 +609,29 @@ class FullApplicationTest extends PHPUnit_Framework_TestCase
     {
         $app = new Application();
 
-        $app->group(['prefix' => 'hello'], function($app) {
-
-            $app->group(['prefix' => 'world'], function($app) {
-                $app->get('/world', "Class@method");
+        $app->group(['prefix' => 'hello'], function ($app) {
+            $app->group(['prefix' => 'world'], function ($app) {
+                $app->get('/world', 'Class@method');
             });
         });
 
         $routes = $app->getRoutes();
 
-        $this->assertArrayHasKey("GET/hello/world/world", $routes);
-
+        $this->assertArrayHasKey('GET/hello/world/world', $routes);
     }
 
     public function testNestedGroupAsRequest()
     {
         $app = new Application();
 
-        $app->group(['as' => 'hello'], function($app) {
-
-            $app->group(['as' => 'world'], function($app) {
-                $app->get('/world', "Class@method");
+        $app->group(['as' => 'hello'], function ($app) {
+            $app->group(['as' => 'world'], function ($app) {
+                $app->get('/world', 'Class@method');
             });
         });
 
-        $this->assertArrayHasKey("hello.world", $app->namedRoutes);
-        $this->assertEquals("/world", $app->namedRoutes['hello.world']);
+        $this->assertArrayHasKey('hello.world', $app->namedRoutes);
+        $this->assertEquals('/world', $app->namedRoutes['hello.world']);
     }
 }
 

--- a/tests/FullApplicationTest.php
+++ b/tests/FullApplicationTest.php
@@ -568,6 +568,74 @@ class FullApplicationTest extends PHPUnit_Framework_TestCase
 
         $this->assertTrue(class_exists('Foo'));
     }
+
+    public function testNestedGroupMiddlewaresRequest()
+    {
+        $app = new Application();
+
+        $app->group(['middleware' => 'middleware1'], function($app) {
+           $app->group(['middleware' => 'middleware2'], function($app) {
+               $app->get('test', "LumenTestController@show");
+           });
+        });
+
+        $route = $app->getRoutes()['GET/test'];
+
+        $this->assertEquals([
+            'middleware1',
+            'middleware2'
+        ], $route['action']['middleware']);
+    }
+
+    public function testNestedGroupNamespaceRequest()
+    {
+        $app = new Application();
+
+        $app->group(['namespace' => 'Hello'], function($app) {
+
+            $app->group(['namespace' => 'World'], function($app) {
+                $app->get('/world', "Class@method");
+            });
+        });
+
+        $routes = $app->getRoutes();
+
+        $route = $routes["GET/world"];
+
+        $this->assertEquals('Hello\\World\\Class@method', $route['action']['uses']);
+    }
+
+    public function testNestedGroupPrefixRequest()
+    {
+        $app = new Application();
+
+        $app->group(['prefix' => 'hello'], function($app) {
+
+            $app->group(['prefix' => 'world'], function($app) {
+                $app->get('/world', "Class@method");
+            });
+        });
+
+        $routes = $app->getRoutes();
+
+        $this->assertArrayHasKey("GET/hello/world/world", $routes);
+
+    }
+
+    public function testNestedGroupAsRequest()
+    {
+        $app = new Application();
+
+        $app->group(['as' => 'hello'], function($app) {
+
+            $app->group(['as' => 'world'], function($app) {
+                $app->get('/world', "Class@method");
+            });
+        });
+
+        $this->assertArrayHasKey("hello.world", $app->namedRoutes);
+        $this->assertEquals("/world", $app->namedRoutes['hello.world']);
+    }
 }
 
 class LumenTestService

--- a/tests/FullApplicationTest.php
+++ b/tests/FullApplicationTest.php
@@ -574,7 +574,7 @@ class FullApplicationTest extends PHPUnit_Framework_TestCase
         $app = new Application();
 
         $app->group(['middleware' => 'middleware1'], function($app) {
-           $app->group(['middleware' => 'middleware2'], function($app) {
+           $app->group(['middleware' => 'middleware2|middleware3'], function($app) {
                $app->get('test', "LumenTestController@show");
            });
         });
@@ -583,7 +583,8 @@ class FullApplicationTest extends PHPUnit_Framework_TestCase
 
         $this->assertEquals([
             'middleware1',
-            'middleware2'
+            'middleware2',
+            'middleware3'
         ], $route['action']['middleware']);
     }
 


### PR DESCRIPTION
Was working with routes in lumen today and had setup a group with namespace.
Inside that group i was also using another group to set some authentication middleware, and here comes the problem.

When i created routes inside the second group, none of the routes got the attributes from the first group.
The problem is also descripbed in #239 where the second group could not find the (expected) namespace for the controller.

As also mentioned in the same issue, the docs do show that you have to write the full namespace again, but this feels very bloated.

This PR includes
 * Tests for
    * nested `'as' => 'name'`
    * nested `'namespace' => 'Hello'`
    * nested `'middleware' => 'hello|world'`
    * nested `'prefix' => '/hello'`

* Changing how groups works for lumen routes

This will be a breaking change since routes with nested grouping will now behave differently