### PR TITLE
[5.3] Migrations should run first in setUpTraits

### DIFF
--- a/src/Testing/TestCase.php
+++ b/src/Testing/TestCase.php
@@ -78,7 +78,7 @@ abstract class TestCase extends PHPUnit_Framework_TestCase
     protected function setUpTraits()
     {
         $uses = array_flip(class_uses_recursive(get_class($this)));
-        
+
         if (isset($uses[DatabaseMigrations::class])) {
             $this->runDatabaseMigrations();
         }

--- a/src/Testing/TestCase.php
+++ b/src/Testing/TestCase.php
@@ -78,13 +78,13 @@ abstract class TestCase extends PHPUnit_Framework_TestCase
     protected function setUpTraits()
     {
         $uses = array_flip(class_uses_recursive(get_class($this)));
+        
+        if (isset($uses[DatabaseMigrations::class])) {
+            $this->runDatabaseMigrations();
+        }
 
         if (isset($uses[DatabaseTransactions::class])) {
             $this->beginDatabaseTransaction();
-        }
-
-        if (isset($uses[DatabaseMigrations::class])) {
-            $this->runDatabaseMigrations();
         }
 
         if (isset($uses[WithoutMiddleware::class])) {


### PR DESCRIPTION
Got this issue when testing on sqlite in memory config for testing.

Looks like Laravel Framework updated in that too https://github.com/laravel/framework/blob/5.3/src/Illuminate/Foundation/Testing/TestCase.php#L99

Maybe this should be target to 5.2 too.