### PR TITLE
Quick fix for incorrect routing when app root is in subfolder #525 

### DIFF
--- a/src/Concerns/RoutesRequests.php
+++ b/src/Concerns/RoutesRequests.php
@@ -692,8 +692,8 @@ trait RoutesRequests
     {
         $query = isset($_SERVER['QUERY_STRING']) ? $_SERVER['QUERY_STRING'] : '';
 
-        /* APP_BASEURL should be like /app or null */
-        return '/'.substr('/'.trim(str_replace('?'.$query, '', $_SERVER['REQUEST_URI']), '/'), strlen(env('APP_BASEURL' ,'')));
+        /* APP_BASEPATH should be like /app or null */
+        return '/'.substr('/'.trim(str_replace('?'.$query, '', $_SERVER['REQUEST_URI']), '/'), strlen(env('APP_BASEPATH', '/')));
     }
 
     /**

--- a/src/Concerns/RoutesRequests.php
+++ b/src/Concerns/RoutesRequests.php
@@ -692,7 +692,8 @@ trait RoutesRequests
     {
         $query = isset($_SERVER['QUERY_STRING']) ? $_SERVER['QUERY_STRING'] : '';
 
-        return '/'.trim(str_replace('?'.$query, '', $_SERVER['REQUEST_URI']), '/');
+        /* APP_BASEURL should be like /app or null */
+        return '/'.substr('/'.trim(str_replace('?'.$query, '', $_SERVER['REQUEST_URI']), '/'), strlen(env('APP_BASEURL' ,'')));
     }
 
     /**


### PR DESCRIPTION
/* Sorry about the failing tests. Hope that's fixed. */

The current routing handler seems to simplify the getBasePath() function, causing routing problems when the app root is in subfolder.

Introducing optional APP_BASEURL is a quick fix for this, as the full logic of getBasePath in HttpFoundation/Request is really heavy.

Discussion is welcome.