### PR TITLE
Run responses from exception handlers through prepareResponse

### DIFF
--- a/src/Concerns/RoutesRequests.php
+++ b/src/Concerns/RoutesRequests.php
@@ -534,9 +534,11 @@ trait RoutesRequests
                 );
             });
         } catch (Exception $e) {
-            return $this->sendExceptionToHandler($e);
+            $response = $this->sendExceptionToHandler($e);
+            return $this->prepareResponse($response);
         } catch (Throwable $e) {
-            return $this->sendExceptionToHandler($e);
+            $response = $this->sendExceptionToHandler($e);
+            return $this->prepareResponse($response);
         }
     }
 


### PR DESCRIPTION
If you try to return non symfony response from an exception handler (for example an array, or PSR-7 responses) you get an exception that the object could not be converted to a string (see [here](https://github.com/laravel/lumen-framework/blob/5.3/src/Concerns/RoutesRequests.php#L478)).

This is inconsistent with the behavior from controllers or invokable controllers who can return those types without problem because they are run through the prepareResponse method.

This small patch runs the responses from the exception handlers through the same function to allow consistent behaviour from controllers and exception handlers.