### PR TITLE
Support HttpFoundation requests

### DIFF
--- a/src/Application.php
+++ b/src/Application.php
@@ -16,6 +16,7 @@ use Illuminate\Support\ServiceProvider;
 use Zend\Diactoros\Response as PsrResponse;
 use Illuminate\Config\Repository as ConfigRepository;
 use Symfony\Bridge\PsrHttpMessage\Factory\DiactorosFactory;
+use Symfony\Component\HttpFoundation\Request as SymfonyRequest;
 
 class Application extends Container
 {
@@ -439,11 +440,15 @@ class Application extends Container
     /**
      * Prepare the given request instance for use with the application.
      *
-     * @param   \Illuminate\Http\Request  $request
+     * @param  \Symfony\Component\HttpFoundation\Request $request
      * @return \Illuminate\Http\Request
      */
-    protected function prepareRequest(Request $request)
+    protected function prepareRequest(SymfonyRequest $request)
     {
+        if (! $request instanceof Request) {
+            $request = Request::createFromBase($request);
+        }
+
         $request->setUserResolver(function ($guard = null) {
             return $this->make('auth')->guard($guard)->user();
         })->setRouteResolver(function () {

--- a/src/Concerns/RoutesRequests.php
+++ b/src/Concerns/RoutesRequests.php
@@ -543,7 +543,7 @@ trait RoutesRequests
     /**
      * Parse the incoming request and return the method and path info.
      *
-     * @param  \Illuminate\Http\Request|null  $request
+     * @param  \Symfony\Component\HttpFoundation\Request|null  $request
      * @return array
      */
     protected function parseIncomingRequest($request)

--- a/tests/FullApplicationTest.php
+++ b/tests/FullApplicationTest.php
@@ -3,6 +3,7 @@
 use Mockery as m;
 use Illuminate\Http\Request;
 use Laravel\Lumen\Application;
+use Symfony\Component\HttpFoundation\Request as SymfonyRequest;
 
 class FullApplicationTest extends PHPUnit_Framework_TestCase
 {
@@ -23,6 +24,18 @@ class FullApplicationTest extends PHPUnit_Framework_TestCase
 
         $this->assertEquals(200, $response->getStatusCode());
         $this->assertEquals('Hello World', $response->getContent());
+    }
+
+    public function testBasicSymfonyRequest()
+    {
+        $app = new Application;
+
+        $app->get('/', function () {
+            return response('Hello World');
+        });
+
+        $response = $app->handle(SymfonyRequest::create('/', 'GET'));
+        $this->assertEquals(200, $response->getStatusCode());
     }
 
     public function testAddRouteMultipleMethodRequest()


### PR DESCRIPTION
Prevents a type error when calling Application::handle with a Symfony Request.  Useful if you are using the PSR-7 bridge since it creates a Symfony request.