### PR TITLE
Calling phpunit asserter statically from MakesHttpRequests trait

### DIFF
--- a/src/Testing/Concerns/MakesHttpRequests.php
+++ b/src/Testing/Concerns/MakesHttpRequests.php
@@ -183,7 +183,7 @@ trait MakesHttpRequests
             json_decode($this->response->getContent(), true)
         ));
 
-        $this->assertEquals(json_encode(array_sort_recursive($data)), $actual);
+        PHPUnit::assertEquals(json_encode(array_sort_recursive($data)), $actual);
 
         return $this;
     }
@@ -198,7 +198,7 @@ trait MakesHttpRequests
     public function seeJson(array $data = null, $negate = false)
     {
         if (is_null($data)) {
-            $this->assertJson(
+            PHPUnit::assertJson(
                 $this->response->getContent(), "JSON was not returned from [{$this->currentUri}]."
             );
 
@@ -238,16 +238,16 @@ trait MakesHttpRequests
 
         foreach ($structure as $key => $value) {
             if (is_array($value) && $key === '*') {
-                $this->assertInternalType('array', $responseData);
+                PHPUnit::assertInternalType('array', $responseData);
 
                 foreach ($responseData as $responseDataItem) {
                     $this->seeJsonStructure($structure['*'], $responseDataItem);
                 }
             } elseif (is_array($value)) {
-                $this->assertArrayHasKey($key, $responseData);
+                PHPUnit::assertArrayHasKey($key, $responseData);
                 $this->seeJsonStructure($structure[$key], $responseData[$key]);
             } else {
-                $this->assertArrayHasKey($value, $responseData);
+                PHPUnit::assertArrayHasKey($value, $responseData);
             }
         }
 
@@ -268,7 +268,7 @@ trait MakesHttpRequests
         $actual = json_decode($this->response->getContent(), true);
 
         if (is_null($actual) || $actual === false) {
-            return $this->fail('Invalid JSON was returned from the route. Perhaps an exception was thrown?');
+            return PHPUnit::fail('Invalid JSON was returned from the route. Perhaps an exception was thrown?');
         }
 
         $actual = json_encode(array_sort_recursive(
@@ -278,7 +278,7 @@ trait MakesHttpRequests
         foreach (array_sort_recursive($data) as $key => $value) {
             $expected = $this->formatToExpectedJson($key, $value);
 
-            $this->{$method}(
+            call_user_func(['PHPUnit_Framework_Assert', $method],
                 Str::contains($actual, $expected),
                 ($negate ? 'Found unexpected' : 'Unable to find')." JSON fragment [{$expected}] within [{$actual}]."
             );
@@ -427,10 +427,10 @@ trait MakesHttpRequests
     {
         $headers = $this->response->headers;
 
-        $this->assertTrue($headers->has($headerName), "Header [{$headerName}] not present on response.");
+        PHPUnit::assertTrue($headers->has($headerName), "Header [{$headerName}] not present on response.");
 
         if (! is_null($value)) {
-            $this->assertEquals(
+            PHPUnit::assertEquals(
                 $headers->get($headerName), $value,
                 "Header [{$headerName}] was found, but value [{$headers->get($headerName)}] does not match [{$value}]."
             );


### PR DESCRIPTION
I was thinking about reusing the `MakesHttpRequests` trait but found after poking through it an inconsistent approach to calls to PHPUnit's asserter. In some cases [it is being called non-statically](https://github.com/laravel/lumen-framework/blob/aa71978a2d855b862137b42883943930df54145e/src/Testing/Concerns/MakesHttpRequests.php#L186), while in other cases [it is being called statically](https://github.com/laravel/lumen-framework/blob/aa71978a2d855b862137b42883943930df54145e/src/Testing/Concerns/MakesHttpRequests.php#L390). I've converted all of these to static calls.

One issue still remains, however: this trait depends on several external properties:

```php
$this->baseUrl

$this->app
```

Is it alright to use the `app()` helper to get around this problem?

Unfortunately, I believe none of the tests cover this trait.