### PR TITLE
[5.4] Add AuthManager binding

### DIFF
--- a/src/Application.php
+++ b/src/Application.php
@@ -841,6 +841,7 @@ class Application extends Container
     public $availableBindings = [
         'auth' => 'registerAuthBindings',
         'auth.driver' => 'registerAuthBindings',
+        'Illuminate\Auth\AuthManager' => 'registerAuthBindings',
         'Illuminate\Contracts\Auth\Guard' => 'registerAuthBindings',
         'Illuminate\Contracts\Auth\Access\Gate' => 'registerAuthBindings',
         'Illuminate\Contracts\Broadcasting\Broadcaster' => 'registerBroadcastingBindings',


### PR DESCRIPTION
If you try to resolve the AuthManager it doesn't call the service provider
which results in a 'cannot resolve parameter app' error because Lumen
doesn't implement `Illuminate\Foundation\Application` and there isn't a typehint.

I'm using the AuthManager directly and not the factory contract because I need
to call `AuthManager@extend`.