### PR TITLE
[5.3] Accept FQN for controller in namespaced group

### DIFF
--- a/src/Concerns/RoutesRequests.php
+++ b/src/Concerns/RoutesRequests.php
@@ -158,7 +158,7 @@ trait RoutesRequests
     protected static function formatUsesPrefix($new, $old)
     {
         if (isset($new['namespace'])) {
-            return isset($old['namespace'])
+            return isset($old['namespace']) && strpos($new['namespace'], '\\') !== 0
                 ? trim($old['namespace'], '\\').'\\'.trim($new['namespace'], '\\')
                 : trim($new['namespace'], '\\');
         }


### PR DESCRIPTION
Problem:
This won't work (in `routes.php`): 

```
$app->group(['namespace' => \Namespace'], function() use ($app) {
    $app->get('my-route', 'MyController@index');
});
```

Error:

> Class App\Http\Controllers\Namespace\MyController does not exist

But it should work, because there is a heading backslash in namespace (it's a fully qualified name).

Solution: check backslash in the beginning of the string in formatUsesPrefix method before adding "old" namespace.

_Side note: Same problem fixed here: https://github.com/laravel/framework/pull/7859_