### PR TITLE
Add doesNotExpectJobs() to TestCase.php

### DIFF
--- a/src/Testing/TestCase.php
+++ b/src/Testing/TestCase.php
@@ -250,6 +250,34 @@ abstract class TestCase extends PHPUnit_Framework_TestCase
     }
 
     /**
+     * Specify a list of jobs that should not be dispatched for the given operation.
+     *
+     * These jobs will be mocked, so that handlers will not actually be executed.
+     *
+     * @param  array|string  $jobs
+     * @return $this
+     */
+    protected function doesNotExpectJobs($jobs)
+    {
+        $jobs = is_array($jobs) ? $jobs : func_get_args();
+
+        unset($this->app->availableBindings['Illuminate\Contracts\Bus\Dispatcher']);
+
+        $mock = Mockery::mock('Illuminate\Bus\Dispatcher[dispatch]', [$this->app]);
+
+        foreach ($jobs as $job) {
+            $mock->shouldReceive('dispatch')->never()
+                ->with(Mockery::type($job));
+        }
+
+        $this->app->instance(
+            'Illuminate\Contracts\Bus\Dispatcher', $mock
+        );
+
+        return $this;
+    }
+
+    /**
      * Mock the job dispatcher so all jobs are silenced and collected.
      *
      * @return $this


### PR DESCRIPTION
Add `doesNotExpectJobs()`. Basically the inverse of `expectsJobs()`.

Allows you to ensure a specific job(s) is **not** dispatched by your method.