### PR TITLE
Assert the response has a given data-structure

### DIFF
--- a/src/Testing/Concerns/MakesHttpRequests.php
+++ b/src/Testing/Concerns/MakesHttpRequests.php
@@ -255,6 +255,44 @@ trait MakesHttpRequests
     }
 
     /**
+     * Assert that the JSON response has a given structure with contents.
+     *
+     * @param  array|null  $structuredData
+     * @param  array|null  $responseData
+     * @return $this
+     */
+    public function seeJsonStructureContains(array $structuredData = null, $responseData = null)
+    {
+        if (is_null($structuredData)) {
+            return $this->seeJson();
+        }
+
+        if (! $responseData) {
+            $responseData = json_decode($this->response->getContent(), true);
+        }
+
+        foreach ($structuredData as $key => $value) {
+            if (is_array($value) && $key === '*') {
+                PHPUnit::assertInternalType('array', $responseData);
+
+                foreach ($responseData as $responseDataItem) {
+                    $this->seeJsonStructureContains($structuredData['*'], $responseDataItem);
+                }
+            } elseif (is_array($value)) {
+                PHPUnit::assertArrayHasKey($key, $responseData);
+                $this->seeJsonStructureContains($structuredData[$key], $responseData[$key]);
+            } else {
+                PHPUnit::assertArrayHasKey($key, $responseData);
+                if ($value !== '*') {
+                    $this->assertEquals($value, $responseData[$key]);
+                }
+            }
+        }
+
+        return $this;
+    }
+
+    /**
      * Assert that the response contains the given JSON.
      *
      * @param  array  $data


### PR DESCRIPTION
Assert that the JSON response has a given structure with contents.
Example:
```
        $jsonStructureContains = [
            'status' => 'success',
            'message' => '*',
            'code' => 2000,
            'data' => [
                'results' => [
                    '*' => [
                        'id' => '*', 'lat' => '*', 'lng' => '*', 'saved_address' => true
                    ]
                ],
                "total" => '*',
                "paginate" => []
            ]
        ];
        $response->seeJsonStructureContains($jsonStructureContains);
```