### PR TITLE
Update event docblock

### DIFF
--- a/src/helpers.php
+++ b/src/helpers.php
@@ -174,7 +174,7 @@ if (! function_exists('event')) {
     /**
      * Fire an event and call the listeners.
      *
-     * @param  string  $event
+     * @param  object|string  $event
      * @param  mixed   $payload
      * @param  bool    $halt
      * @return array|null


### PR DESCRIPTION
The $event variabel accepts both strings and objects. This should be mentioned within the functions documentation.
Some of my code inspections fail because I insert an object (which is possible).

> new \App\Events\MyEvent.......) is of type object<App\Events\MyEvent>, but the function (event) expects a string.