### PR TITLE
Properly create a Request instance to fix tests

### DIFF
--- a/src/Application.php
+++ b/src/Application.php
@@ -422,18 +422,6 @@ class Application extends Container
     }
 
     /**
-     * Register container bindings for the application.
-     *
-     * @return void
-     */
-    protected function registerRequestBindings()
-    {
-        $this->singleton('Illuminate\Http\Request', function () {
-            return $this->prepareRequest(Request::capture());
-        });
-    }
-
-    /**
      * Prepare the given request instance for use with the application.
      *
      * @param  \Symfony\Component\HttpFoundation\Request $request
@@ -868,10 +856,8 @@ class Application extends Container
         'queue.connection' => 'registerQueueBindings',
         'Illuminate\Contracts\Queue\Factory' => 'registerQueueBindings',
         'Illuminate\Contracts\Queue\Queue' => 'registerQueueBindings',
-        'request' => 'registerRequestBindings',
         'Psr\Http\Message\ServerRequestInterface' => 'registerPsrRequestBindings',
         'Psr\Http\Message\ResponseInterface' => 'registerPsrResponseBindings',
-        'Illuminate\Http\Request' => 'registerRequestBindings',
         'translator' => 'registerTranslationBindings',
         'url' => 'registerUrlGeneratorBindings',
         'validator' => 'registerValidatorBindings',

--- a/src/Concerns/RoutesRequests.php
+++ b/src/Concerns/RoutesRequests.php
@@ -549,10 +549,11 @@ trait RoutesRequests
     {
         if ($request) {
             $this->instance(Request::class, $this->prepareRequest($request));
-            $this->ranServiceBinders['registerRequestBindings'] = true;
 
             return [$request->getMethod(), $request->getPathInfo()];
         } else {
+            $this->instance(Request::class, Request::capture());
+
             return [$this->getMethod(), $this->getPathInfo()];
         }
     }


### PR DESCRIPTION
While running tests, the `Request` singleton causes the instance registration not to be considered while calling `parseIncomingRequest()`.

In this PR I drop the usage of `singleton()` and register the instance from within `parseIncomingRequest()`, that way the request we get from `Request::capture()` will only be used in normal HTTP requests, while in unit tests the Request we create while using `call, get, post...` will be used.