### PR TITLE
Fix Request Binding on initial bootstrap

### DIFF
--- a/src/Application.php
+++ b/src/Application.php
@@ -422,6 +422,18 @@ class Application extends Container
     }
 
     /**
+     * Register container bindings for the application.
+     *
+     * @return void
+     */
+    protected function registerRequestBindings()
+    {
+        $this->singleton('Illuminate\Http\Request', function () {
+            return $this->prepareRequest(Request::capture());
+        });
+    }
+
+    /**
      * Prepare the given request instance for use with the application.
      *
      * @param  \Symfony\Component\HttpFoundation\Request $request
@@ -858,6 +870,7 @@ class Application extends Container
         'Illuminate\Contracts\Queue\Queue' => 'registerQueueBindings',
         'Psr\Http\Message\ServerRequestInterface' => 'registerPsrRequestBindings',
         'Psr\Http\Message\ResponseInterface' => 'registerPsrResponseBindings',
+        'Illuminate\Http\Request' => 'registerRequestBindings',
         'translator' => 'registerTranslationBindings',
         'url' => 'registerUrlGeneratorBindings',
         'validator' => 'registerValidatorBindings',


### PR DESCRIPTION
Hello, while trying to work on a new API with lumen 5.4 today I discovered an issue with how the request is bound to the app. I believe this will also take care of #565.

If I have the below code in my lumen app inside a service provider, lumen 5.3 returns 'OPTIONS' (which is correct), whereas 5.4 returns 'GET' -- the default for a blank request. In my case I'm trying to consume my lumen API with vue / axios from another (regular laravel) app.
```
  public function register()
  {
    $request = $this->app->request;

    dd($request->getMethod()); // This is 'GET' when it should be 'OPTIONS' in my case
    ...
  }
```

I noticed that @themsaid made this commit https://github.com/laravel/lumen-framework/commit/2ce2eaaaebd315eefcba312de1e568a1b39fcaa5#diff-c9248b3167fc44af085b81db2e292837L874 recently, so I tried to do some guess and check working backwards from that. Given that I'm not super familiar with the app bootstrap process, I didn't fully understand the intent of @themsaid 's change. That said, there may be a better way to handle this, but my fix seems to work and the tests passed on my local machine! 