### PR TITLE
Always resolve the UrlGenerator from the container

### DIFF
--- a/src/helpers.php
+++ b/src/helpers.php
@@ -291,8 +291,7 @@ if (! function_exists('route')) {
      */
     function route($name, $parameters = [], $secure = null)
     {
-        return (new Laravel\Lumen\Routing\UrlGenerator(app()))
-                ->route($name, $parameters, $secure);
+        return app('url')->route($name, $parameters, $secure);
     }
 }
 
@@ -339,8 +338,7 @@ if (! function_exists('url')) {
      */
     function url($path = null, $parameters = [], $secure = null)
     {
-        return (new Laravel\Lumen\Routing\UrlGenerator(app()))
-                                ->to($path, $parameters, $secure);
+        return app('url')->to($path, $parameters, $secure);
     }
 }
 


### PR DESCRIPTION
I was profiling a large lumen application and realized that the app was spending a lot of time in the UrlGenerator.

Because the `route` and `url` helper functions don't resolve the UrlGenerator from the container, the scheme and root are never cached.  Since they aren't cached the UrlGenerator resolves the request every time.

This PR changes the helper functions to use the container, since the UrlGenerator is bound as a singleton.  On an endpoint that generates a lot of links this made it 20% faster.