### PR TITLE
Always get the method and path from the Illuminate Request

### DIFF
--- a/src/Concerns/RoutesRequests.php
+++ b/src/Concerns/RoutesRequests.php
@@ -547,15 +547,13 @@ trait RoutesRequests
      */
     protected function parseIncomingRequest($request)
     {
-        if ($request) {
-            $this->instance(Request::class, $this->prepareRequest($request));
-
-            return [$request->getMethod(), $request->getPathInfo()];
-        } else {
-            $this->instance(Request::class, Request::capture());
-
-            return [$this->getMethod(), $this->getPathInfo()];
+        if (! $request) {
+            $request = Request::capture();
         }
+
+        $this->instance(Request::class, $this->prepareRequest($request));
+
+        return [$request->getMethod(), $request->getPathInfo()];
     }
 
     /**
@@ -800,32 +798,6 @@ trait RoutesRequests
         }
 
         return $response;
-    }
-
-    /**
-     * Get the current HTTP request method.
-     *
-     * @return string
-     */
-    protected function getMethod()
-    {
-        if (isset($_POST['_method'])) {
-            return strtoupper($_POST['_method']);
-        } else {
-            return $_SERVER['REQUEST_METHOD'];
-        }
-    }
-
-    /**
-     * Get the current HTTP path info.
-     *
-     * @return string
-     */
-    protected function getPathInfo()
-    {
-        $query = isset($_SERVER['QUERY_STRING']) ? $_SERVER['QUERY_STRING'] : '';
-
-        return '/'.trim(str_replace('?'.$query, '', $_SERVER['REQUEST_URI']), '/');
     }
 
     /**

--- a/tests/FullApplicationTest.php
+++ b/tests/FullApplicationTest.php
@@ -57,44 +57,6 @@ class FullApplicationTest extends PHPUnit_Framework_TestCase
         $this->assertEquals('Hello World', $response->getContent());
     }
 
-    public function testRequestWithoutSymfonyClass()
-    {
-        $app = new Application;
-
-        $app->get('/', function () {
-            return response('Hello World');
-        });
-
-        $_SERVER['REQUEST_METHOD'] = 'GET';
-        $_SERVER['REQUEST_URI'] = '/';
-
-        $response = $app->dispatch();
-
-        $this->assertEquals(200, $response->getStatusCode());
-        $this->assertEquals('Hello World', $response->getContent());
-
-        unset($_SERVER['REQUEST_METHOD'], $_SERVER['REQUEST_URI']);
-    }
-
-    public function testRequestWithoutSymfonyClassTrailingSlash()
-    {
-        $app = new Application;
-
-        $app->get('/foo', function () {
-            return response('Hello World');
-        });
-
-        $_SERVER['REQUEST_METHOD'] = 'GET';
-        $_SERVER['REQUEST_URI'] = '/foo/';
-
-        $response = $app->dispatch();
-
-        $this->assertEquals(200, $response->getStatusCode());
-        $this->assertEquals('Hello World', $response->getContent());
-
-        unset($_SERVER['REQUEST_METHOD'], $_SERVER['REQUEST_URI']);
-    }
-
     public function testRequestWithParameters()
     {
         $app = new Application;


### PR DESCRIPTION
Now that #558 is merged, we always create a Request instance before routing.

Since we have a request instance, we can go ahead and use that to get the current method and path, which fixes #533.  Calling `getPathInfo` and `getMethod` only takes ~.1 nanosecond so it shouldn't affect performance.

I also made sure `prepareRequest` is always called so that the route resolver and user resolver are set.

It looks like the path when you weren't using the Request class was trimming the trailing slash, but that doesn't happen when using a Request.  It doesn't look like the full Laravel framework trims trailing slashes so I kept it as is.