### PR TITLE
[5.4] Default to null if amount isn't set in factory helper

### DIFF
--- a/src/helpers.php
+++ b/src/helpers.php
@@ -201,7 +201,7 @@ if (! function_exists('factory')) {
         $arguments = func_get_args();
 
         if (isset($arguments[1]) && is_string($arguments[1])) {
-            return $factory->of($arguments[0], $arguments[1])->times(isset($arguments[2]) ? $arguments[2] : 1);
+            return $factory->of($arguments[0], $arguments[1])->times(isset($arguments[2]) ? $arguments[2] : null);
         } elseif (isset($arguments[1])) {
             return $factory->of($arguments[0])->times($arguments[1]);
         } else {


### PR DESCRIPTION
Ports the fix from laravel/framework#17614 to Lumen.

This fixes calls to the `factory()` helper which don't specify an amount returning a Collection of a single element (because of laravel/framework#17493), when they should be returning the model instance itself.