### PR TITLE
Fix json parameters not loaded in tests for `json` calls

### DIFF
--- a/src/Testing/Concerns/MakesHttpRequests.php
+++ b/src/Testing/Concerns/MakesHttpRequests.php
@@ -5,6 +5,7 @@ namespace Laravel\Lumen\Testing\Concerns;
 use Illuminate\Support\Str;
 use Illuminate\Http\Request;
 use PHPUnit\Framework\Assert as PHPUnit;
+use Symfony\Component\HttpFoundation\Request as SymfonyRequest;
 
 trait MakesHttpRequests
 {
@@ -325,13 +326,13 @@ trait MakesHttpRequests
     {
         $this->currentUri = $this->prepareUrlForRequest($uri);
 
-        $request = Request::create(
+        $symfonyRequest = SymfonyRequest::create(
             $this->currentUri, $method, $parameters,
             $cookies, $files, $server, $content
         );
 
         return $this->response = $this->app->prepareResponse(
-            $this->app->handle($request)
+            $this->app->handle(Request::createFromBase($symfonyRequest))
         );
     }
 


### PR DESCRIPTION
This PR fixes the issue of the json parameters not being loaded in tests that use the `json` call.

The function `getInputSource` is called in the `Request::createFromBase` which loads the json on the Request but that does not happen when the request is created straight using `SymfonyRequest::create`.

Fixes #522, #55