### PR TITLE
Use PHPUnit Namespace

### DIFF
--- a/src/Testing/Concerns/MakesHttpRequests.php
+++ b/src/Testing/Concerns/MakesHttpRequests.php
@@ -279,7 +279,7 @@ trait MakesHttpRequests
         foreach (array_sort_recursive($data) as $key => $value) {
             $expected = $this->formatToExpectedJson($key, $value);
 
-            call_user_func(['PHPUnit\Framework\Assert', $method],
+            call_user_func([PHPUnit::class, $method],
                 Str::contains($actual, $expected),
                 ($negate ? 'Found unexpected' : 'Unable to find')." JSON fragment [{$expected}] within [{$actual}]."
             );

--- a/src/Testing/Concerns/MakesHttpRequests.php
+++ b/src/Testing/Concerns/MakesHttpRequests.php
@@ -279,7 +279,7 @@ trait MakesHttpRequests
         foreach (array_sort_recursive($data) as $key => $value) {
             $expected = $this->formatToExpectedJson($key, $value);
 
-            call_user_func(['PHPUnit_Framework_Assert', $method],
+            call_user_func(['PHPUnit\Framework\Assert', $method],
                 Str::contains($actual, $expected),
                 ($negate ? 'Found unexpected' : 'Unable to find')." JSON fragment [{$expected}] within [{$actual}]."
             );


### PR DESCRIPTION
This PR allows upgrading to *PHPUnit 6* for Lumen 5.4 testing, while maintaining backwards compatibility with *PHPUnit 5.7* - it appears that all other references to `PHPUnit_Framework_Assert` have already been migrated and this is the only one left dangling.

In *PHPUnit 6,* PHPUnit's units of code are now namespaced. While *PHPUnit 5.7* has a forward compatibility layer, meaning we can already use `PHPUnit\Framework\{Class}` with that version, there is no backward compatibility layer in *PHPUnit 6* that allows you to use `PHPUnit_Framework_{Class}.`