### PR TITLE
[5.4] Merge config loaded from config files rather than overwriting

### DIFF
--- a/src/Application.php
+++ b/src/Application.php
@@ -572,7 +572,9 @@ class Application extends Container
         $path = $this->getConfigurationPath($name);
 
         if ($path) {
-            $this->make('config')->set($name, require $path);
+            $config = $this->make('config');
+
+            $config->set($name, array_merge(require $path, $config->get($name, [])));
         }
     }
 

--- a/src/Application.php
+++ b/src/Application.php
@@ -574,7 +574,7 @@ class Application extends Container
         if ($path) {
             $config = $this->make('config');
 
-            $config->set($name, array_merge(require $path, $config->get($name, [])));
+            $config->set($name, array_replace_recursive(require $path, $config->get($name, [])));
         }
     }
 


### PR DESCRIPTION
Currently, Lumen just overwrites any configuration set in the same namespace when loading config values from the config files. This PR changes that so it preserves any configuration values already set.

### Use case

I wanted to use a `sqlite` connection for my database, and in order to specify the correct path, I can't use the .env file, because I needed to set the value dynamically.

I decided to use the `config` helper to set the database path inside of the AppServiceProvider. The value would get overwritten as soon as I actually used any of the Database functionality. A solution was to call `app()->configure('database')` before calling the config helper, but that seemed a bit redundant.

### Example code

_AppServiceProvider.php_
```php
<?php

namespace App\Providers;

use Illuminate\Support\ServiceProvider;

class AppServiceProvider extends ServiceProvider
{
    /**
     * Register any application services.
     *
     * @return void
     */
    public function register()
    {
        config(['database.connections.sqlite.database' => storage_path('app/database.sqlite')]);
        
        $db = app('db');
        
        dd(config('database.connections.sqlite.database'));
    }
}
```

**Result:** (before PR)
```
vendor/illuminate/support/Debug/Dumper.php:23:string 'database/database.sqlite'
```

**Result:** (after PR)
```
vendor/illuminate/support/Debug/Dumper.php:23:string 'storage/app/database.sqlite'
```