### PR TITLE
Environment detection

### DIFF
--- a/src/Application.php
+++ b/src/Application.php
@@ -133,7 +133,7 @@ class Application extends Container
      */
     public function environment()
     {
-        $env = env('APP_ENV', 'production');
+        $env = env('APP_ENV', config('app.env', 'production'));
 
         if (func_num_args() > 0) {
             $patterns = is_array(func_get_arg(0)) ? func_get_arg(0) : func_get_args();

--- a/src/Exceptions/Handler.php
+++ b/src/Exceptions/Handler.php
@@ -94,7 +94,7 @@ class Handler implements ExceptionHandler
 
         $fe = FlattenException::create($e);
 
-        $handler = new SymfonyExceptionHandler(env('APP_DEBUG', false));
+        $handler = new SymfonyExceptionHandler(env('APP_DEBUG', config('app.debug', false)));
 
         $decorated = $this->decorate($handler->getContent($fe), $handler->getStylesheet($fe));
 


### PR DESCRIPTION
Since the Lumen Framework doesn't have the `config:cache` support from Artisan, I had to use `CONFIG` instead of `ENV` for some good and important reasons.

The framework uses `ENV` to set the `APP_ENV` and the `APP_DEBUG` currently. However, as I said, we may have other scenarios.

`// Application.php`
`$env = env('APP_ENV', 'production');`
`// Handler.php`
`$handler = new SymfonyExceptionHandler(env('APP_DEBUG', false));`

In this case, the framework should verify both.

`// Application.php`
`$env = env('APP_ENV', config('app.env', 'production'));`
`// Handler.php`
`$handler = new SymfonyExceptionHandler(env('APP_DEBUG', config('app.debug', false)));`

Thank you.

Based on https://github.com/laravel/lumen-framework/issues/417

Also must see
https://github.com/laravel/lumen-framework/issues/585
https://github.com/laravel/lumen-framework/issues/605