### PR TITLE
Make Redis connection for queues configurable in .env

### DIFF
--- a/config/queue.php
+++ b/config/queue.php
@@ -58,7 +58,7 @@ return [
 
         'redis' => [
             'driver' => 'redis',
-            'connection' => 'default',
+            'connection' => env('QUEUE_REDIS_CONNECTION', 'default'),
             'queue' => 'default',
             'retry_after' => 60,
         ],


### PR DESCRIPTION
`broadcasting.php` and `cache.php` are loading `BROADCAST_REDIS_CONNECTION` and `CACHE_REDIS_CONNECTION` to make them configurable in .env, but `queue.php` is not. It's better and helpful to make them consistent.

https://github.com/laravel/lumen-framework/blob/5.4/config/broadcasting.php#L40
https://github.com/laravel/lumen-framework/blob/5.4/config/cache.php#L61