### PR TITLE
change Application.php __construct function date_default_timezone_set on customize

### DIFF
--- a/src/Application.php
+++ b/src/Application.php
@@ -80,7 +80,9 @@ class Application extends Container
      */
     public function __construct($basePath = null)
     {
-        date_default_timezone_set(env('APP_TIMEZONE', 'UTC'));
+        if (!empty(env('APP_TIMEZONE'))) {
+            date_default_timezone_set(env('APP_TIMEZONE', 'UTC'));
+        }
 
         $this->basePath = $basePath;
 

--- a/src/Application.php
+++ b/src/Application.php
@@ -80,7 +80,7 @@ class Application extends Container
      */
     public function __construct($basePath = null)
     {
-        if ( !empty(env('APP_TIMEZONE')) ) {
+        if (! empty(env('APP_TIMEZONE'))) {
             date_default_timezone_set(env('APP_TIMEZONE', 'UTC'));
         }
 

--- a/src/Application.php
+++ b/src/Application.php
@@ -80,7 +80,7 @@ class Application extends Container
      */
     public function __construct($basePath = null)
     {
-        if (!empty(env('APP_TIMEZONE'))) {
+        if ( !empty(env('APP_TIMEZONE')) ) {
             date_default_timezone_set(env('APP_TIMEZONE', 'UTC'));
         }
 


### PR DESCRIPTION
change reason:
When development or deploy the php application, the devops may be set the php.ini file with config field  `date.timezone` in right value,hens we can check whether the .evn file setted APP_TIMEZONE to change date default_timezone,otherwise We need to change it when __construct at once.