### PR TITLE
Fix a bug with MakesHttpRequests

### DIFF
--- a/src/Testing/Concerns/MakesHttpRequests.php
+++ b/src/Testing/Concerns/MakesHttpRequests.php
@@ -283,7 +283,7 @@ trait MakesHttpRequests
         foreach (array_sort_recursive($data) as $key => $value) {
             $expected = $this->formatToExpectedJson($key, $value);
 
-            call_user_func(['PHPUnit_Framework_Assert', $method],
+            PHPUnit::{$method}(
                 Str::contains($actual, $expected),
                 ($negate ? 'Found unexpected' : 'Unable to find')." JSON fragment [{$expected}] within [{$actual}]."
             );


### PR DESCRIPTION
Fixes #609 

The `seeJsonContains` method used to reference `PHPUnit_Framework_Assert` instead of `PHPUnit\Framework\Assert`