### PR TITLE
Add mockery expectations to the assertion count

### DIFF
--- a/src/Testing/TestCase.php
+++ b/src/Testing/TestCase.php
@@ -104,6 +104,10 @@ abstract class TestCase extends BaseTestCase
     public function tearDown()
     {
         if (class_exists('Mockery')) {
+            if (($container = \Mockery::getContainer()) !== null) {
+                $this->addToAssertionCount($container->mockery_getExpectationCount());
+            }
+
             Mockery::close();
         }
 


### PR DESCRIPTION
This is basically a copy of laravel/framework#20606 but in lumen.

From the pull request laravel/framework#20606:

> Fixes an issue where tests that use mockery expectations that don't have any assertions are marked as risky.
> 
> mockery/mockery#376
> GrahamCampbell/Laravel-TestBench@981289c