### PR TITLE
Fix console service provider clear cache command

### DIFF
--- a/src/Console/ConsoleServiceProvider.php
+++ b/src/Console/ConsoleServiceProvider.php
@@ -110,7 +110,7 @@ class ConsoleServiceProvider extends ServiceProvider
     protected function registerCacheClearCommand()
     {
         $this->app->singleton('command.cache.clear', function ($app) {
-            return new CacheClearCommand($app['cache']);
+            return new CacheClearCommand($app['cache'], $app['files']);
         });
     }
 


### PR DESCRIPTION
Fixes #655

As per the issue, artisan does not work because the signature of the Illuminate\Cache\Console\ClearCommand constructor has changed between 5.4 and 5.5. This fix is based on [Illuminate\Foundation\Providers\ArtisanServiceProvider](https://github.com/laravel/framework/blob/d35e24c409598c231371369dabc8cdc8c92a11d6/src/Illuminate/Foundation/Providers/ArtisanServiceProvider.php#L216)