### PR TITLE
Custom Request object is overridden by default Illuminate\Http\Request

### DIFF
--- a/src/Concerns/RoutesRequests.php
+++ b/src/Concerns/RoutesRequests.php
@@ -183,7 +183,7 @@ trait RoutesRequests
             $request = Request::capture();
         }
 
-        $this->instance(Request::class, $this->prepareRequest($request));
+        $this->instance(get_class($request), $this->prepareRequest($request));
 
         return [$request->getMethod(), '/'.trim($request->getPathInfo(), '/')];
     }

--- a/src/Testing/Concerns/MakesHttpRequests.php
+++ b/src/Testing/Concerns/MakesHttpRequests.php
@@ -336,7 +336,7 @@ trait MakesHttpRequests
         );
 
         return $this->response = $this->app->prepareResponse(
-            $this->app->handle(Request::createFromBase($symfonyRequest))
+            $this->app->handle(app('request')::createFromBase($symfonyRequest))
         );
     }
 


### PR DESCRIPTION
According to https://github.com/laravel/lumen-framework/issues/663

In testing environment `Illuminate\Http\Request` is used and overrides custom `Request` object that is binded to IoC container that makes tests to fail.