### PR TITLE
Get router instance via static method

### DIFF
--- a/src/Routing/Router.php
+++ b/src/Routing/Router.php
@@ -35,6 +35,13 @@ class Router
     public $namedRoutes = [];
 
     /**
+     * Stock the Router instance
+     *
+     * @var Router
+     */
+    private static $_instance;
+
+    /**
      * Router constructor.
      *
      * @param  \Laravel\Lumen\Application  $app
@@ -42,7 +49,20 @@ class Router
     public function __construct($app)
     {
         $this->app = $app;
+
+        self::$_instance = $this;
     }
+
+    /**
+     * Get the current instance
+     *
+     * @return $this|null
+     */
+    public static function getInstance()
+    {
+        return self::$_instance ?: null;
+    }
+
 
     /**
      * Register a set of routes with a set of shared attributes.

--- a/src/Routing/Router.php
+++ b/src/Routing/Router.php
@@ -63,7 +63,6 @@ class Router
         return self::$_instance ?: null;
     }
 
-
     /**
      * Register a set of routes with a set of shared attributes.
      *

--- a/src/Routing/Router.php
+++ b/src/Routing/Router.php
@@ -35,7 +35,7 @@ class Router
     public $namedRoutes = [];
 
     /**
-     * Stock the Router instance
+     * Stock the Router instance.
      *
      * @var Router
      */
@@ -54,7 +54,7 @@ class Router
     }
 
     /**
-     * Get the current instance
+     * Get the current instance.
      *
      * @return $this|null
      */


### PR DESCRIPTION
Adding static method called `getInstance()`. I think it's even better to make it a singleton.

Now, it can be called in routes/web.php:

```
$router = Router::getInstance();

$router->get('/', function () {
    return [
        'message' => 'Hello world!'
    ];
});
```

This method will really help IDE's detect the available methods and parameters that can be used (Autocomplete) with the router object directly , and it remove the warning flag for the `$router ` as it is **undefined variable**. (See screenshot)

![Screenshot from PHPStorm](https://image.ibb.co/mXZa6G/router_instance.png)