### PR TITLE
[5.5] Updated dev dependencies in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -43,8 +43,8 @@
         "symfony/http-foundation": "~3.3"
     },
     "require-dev": {
-        "phpunit/phpunit": "~5.7",
-        "mockery/mockery": "~0.9"
+        "mockery/mockery": "~1.0",
+        "phpunit/phpunit": "~6.0"
     },
     "suggest": {
         "laravel/tinker": "Required to use the tinker console command (~1.0).",


### PR DESCRIPTION
Updated `mockery/mockery` to `~1.0` and `phpunit/phpunit` to `~6.0` to match Laravel Framework [composer file](https://github.com/laravel/framework/blob/5.5/composer.json).