### PR TITLE
Allow groups with no nested attributes

### DIFF
--- a/src/Routing/Router.php
+++ b/src/Routing/Router.php
@@ -115,6 +115,10 @@ class Router
      */
     protected function mergeWithLastGroup($new)
     {
+        if(isset($new['nested']) && $new['nested'] == false){
+            return $this->mergeGroup($new,[]);
+        }
+        
         return $this->mergeGroup($new, end($this->groupStack));
     }
 

--- a/tests/FullApplicationTest.php
+++ b/tests/FullApplicationTest.php
@@ -588,6 +588,23 @@ class FullApplicationTest extends TestCase
         $this->assertEquals('Hello\\World\\Class@method', $route['action']['uses']);
     }
 
+    public function testClearNestedGroupNamespaceRequest()
+    {
+        $app = new Application();
+
+        $app->router->group(['namespace' => 'Hello'], function ($router) {
+            $router->group(['namespace' => 'World','nested' => false], function ($router) {
+                $router->get('/world', 'Class@method');
+            });
+        });
+
+        $routes = $app->router->getRoutes();
+
+        $route = $routes['GET/world'];
+
+        $this->assertEquals('World\\Class@method', $route['action']['uses']);
+    }
+
     public function testNestedGroupPrefixRequest()
     {
         $app = new Application();


### PR DESCRIPTION
Hello Taylor,

This PR solve a problem comes with this #506 **Makes nested groups inherit previous groups attributes**

The above PR makes all routes inside `web.php` file comes with `App/Http/Controller` namespace 

so when you wan to make a route for extended controller from a package like below

```php
<?php
...
$app->group(['namespace' => '\Rap2hpoutre\LaravelLogViewer'], function() use ($app) {
    $app->get('logs', 'LogViewerController@index');
});
```

It will throw an exception 

`Class App\Http\Controllers\Rap2hpoutre\LaravelLogViewer\LogViewerController does not exist`

so you might have to create external route group file in `bootstrap/app.php` file like below

```php
<?php
....
# Original Routes
$app->group(['namespace' => 'App\Http\Controllers'], function ($app) {
    require __DIR__.'/../routes/web.php';
});
# External Routes
$app->group([], function ($app) {
    require __DIR__.'/../routes/externals.php';
});
```

or use this PR additional **attribute** `'nested' => false` like below in the `web.php` routes file 
```php
<?php
...

$app->group(['namespace' => '\Rap2hpoutre\LaravelLogViewer','nested' => false], function() use ($app) {
    $app->get('logs', 'LogViewerController@index');
});
```


Thanks :)