### PR TITLE
Test against PHP 7.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ language: php
 php:
   - 7.0
   - 7.1
+  - 7.2
 
 sudo: false
 


### PR DESCRIPTION
With the release of [`PHP 7.2`](http://php.net/archive/2017.php#id2017-11-30-1), would be nice to test Lumen against it.