### PR TITLE
Fix forced scheme url generation

### DIFF
--- a/src/Routing/UrlGenerator.php
+++ b/src/Routing/UrlGenerator.php
@@ -258,7 +258,7 @@ class UrlGenerator
     {
         if (is_null($secure)) {
             if (is_null($this->cachedScheme)) {
-                $this->cachedScheme = $this->app->make('request')->getScheme().'://';
+                $this->cachedScheme = $this->getScheme($secure);
             }
 
             return $this->cachedScheme;


### PR DESCRIPTION
During url generation we do not look for forced scheme. 
The getSchemeForUrl function should use the getScheme function in order to determinate the appropriate url scheme.