### PR TITLE
[5.5] Don't convert Jsonable data for JsonResponse prematurely

### DIFF
--- a/src/Http/ResponseFactory.php
+++ b/src/Http/ResponseFactory.php
@@ -5,7 +5,6 @@ namespace Laravel\Lumen\Http;
 use Illuminate\Support\Str;
 use Illuminate\Http\Response;
 use Illuminate\Http\JsonResponse;
-use Illuminate\Contracts\Support\Arrayable;
 use Symfony\Component\HttpFoundation\BinaryFileResponse;
 
 class ResponseFactory
@@ -34,10 +33,6 @@ class ResponseFactory
      */
     public function json($data = [], $status = 200, array $headers = [], $options = 0)
     {
-        if ($data instanceof Arrayable) {
-            $data = $data->toArray();
-        }
-
         return new JsonResponse($data, $status, $headers, $options);
     }
 


### PR DESCRIPTION
Responsefactory should not convert the data to an array as JsonReponse will convert the data to an array if necessary before conversion to JSON. JsonResponse needs the original object data to do proper conversion to Json, using the toJson() method on Jsonable objects.

By not converting Jsonable data to an array, setData() in Illuminate\Http\JsonReponse will correctly call toJson() on the data.

In the old behaviour, ResponseFactory would convert to an array, and JsonResponse's setData() would just call json_encode() on it.