### PR TITLE
Provide dispatch_now along with dispatch function

### DIFF
--- a/src/Routing/ProvidesConvenienceMethods.php
+++ b/src/Routing/ProvidesConvenienceMethods.php
@@ -176,7 +176,7 @@ trait ProvidesConvenienceMethods
     {
         return app('Illuminate\Contracts\Bus\Dispatcher')->dispatchNow($job, $handler);
     }
-    
+
     /**
      * Get a validation factory instance.
      *

--- a/src/Routing/ProvidesConvenienceMethods.php
+++ b/src/Routing/ProvidesConvenienceMethods.php
@@ -166,6 +166,18 @@ trait ProvidesConvenienceMethods
     }
 
     /**
+     * Dispatch a command to its appropriate handler in the current process.
+     *
+     * @param  mixed  $job
+     * @param  mixed  $handler
+     * @return mixed
+     */
+    public function dispatch_now($job, $handler = null)
+    {
+        return app('Illuminate\Contracts\Bus\Dispatcher')->dispatchNow($job, $handler);
+    }
+    
+    /**
      * Get a validation factory instance.
      *
      * @return \Illuminate\Contracts\Validation\Factory


### PR DESCRIPTION
When the `dispatch()` function is available via `ProvidesConvenienceMethods` I would assume that I can also access the `dispatch_now()` function.