### PR TITLE
Include the exception in the logger context

### DIFF
--- a/src/Exceptions/Handler.php
+++ b/src/Exceptions/Handler.php
@@ -42,7 +42,7 @@ class Handler implements ExceptionHandler
             throw $e; // throw the original exception
         }
 
-        $logger->error($e);
+        $logger->error($e, ['exception' => $e]);
     }
 
     /**


### PR DESCRIPTION
This PR adds the exception to the logger context array when it is caught by the app's exception handler.

This makes it simple to send exceptions to a service like Sentry using the monolog handler since the exception key is documented in the PSR-3 docs and most handlers check for it.

https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-3-logger-interface.md#13-context