### PR TITLE
Fix Declaration Incompatible Problem

### DIFF
--- a/src/Console/Kernel.php
+++ b/src/Console/Kernel.php
@@ -117,9 +117,9 @@ class Kernel implements KernelContract
      * @param  array  $parameters
      * @return int
      */
-    public function call($command, array $parameters = [])
+    public function call($command, array $parameters = [], $outputBuffer = null)
     {
-        return $this->getArtisan()->call($command, $parameters);
+        return $this->getArtisan()->call($command, $parameters, $outputBuffer);
     }
 
     /**


### PR DESCRIPTION
When Running php artisan, It shows as follows.

> Fatal error: Declaration of Laravel\Lumen\Console\Kernel::call($command, array $parameters = Array) must be compatible with Illuminate\Contracts\Console\Kernel::call($command, array $parameters = Array, $outputBuffer = NULL) in /builds/eshop/b2c/admin/be/vendor/laravel/lumen-framework/src/Console/Kernel.php on line 15