### PR TITLE
App Level Response Builder and Error Formatter

### DIFF
--- a/src/Application.php
+++ b/src/Application.php
@@ -576,6 +576,32 @@ class Application extends Container
     }
 
     /**
+     * Define a response builder for building the failed validation responses.
+     *
+     * @param  callable  $fn
+     * @return $this
+     */
+    public function buildResponseUsing(callable $fn)
+    {
+        $this->instance('routing.responseBuilder', $fn);
+
+        return $this;
+    }
+
+    /**
+     * Define a error formatter for formatting the validation errors.
+     *
+     * @param  callable  $fn
+     * @return $this
+     */
+    public function formatErrorsUsing(callable $fn)
+    {
+        $this->instance('routing.errorFormatter', $fn);
+
+        return $this;
+    }
+
+    /**
      * Get the path to the given configuration file.
      *
      * If no name is provided, then we'll return the path to the config folder.

--- a/src/Routing/ProvidesConvenienceMethods.php
+++ b/src/Routing/ProvidesConvenienceMethods.php
@@ -12,39 +12,27 @@ use Illuminate\Validation\ValidationException;
 trait ProvidesConvenienceMethods
 {
     /**
-     * The response builder callback.
-     *
-     * @var \Closure
-     */
-    protected static $responseBuilder;
-
-    /**
-     * The error formatter callback.
-     *
-     * @var \Closure
-     */
-    protected static $errorFormatter;
-
-    /**
      * Set the response builder callback.
      *
+     * @deprecated
      * @param  \Closure  $callback
      * @return void
      */
     public static function buildResponseUsing(BaseClosure $callback)
     {
-        static::$responseBuilder = $callback;
+        app()->buildResponseUsing($callback);
     }
 
     /**
      * Set the error formatter callback.
      *
+     * @deprecated
      * @param  \Closure  $callback
      * @return void
      */
     public static function formatErrorsUsing(BaseClosure $callback)
     {
-        static::$errorFormatter = $callback;
+        app()->formatErrorsUsing($callback);
     }
 
     /**
@@ -86,8 +74,8 @@ trait ProvidesConvenienceMethods
      */
     protected function buildFailedValidationResponse(Request $request, array $errors)
     {
-        if (isset(static::$responseBuilder)) {
-            return call_user_func(static::$responseBuilder, $request, $errors);
+        if ($this->getResponseBuilder()) {
+            return call_user_func($this->getResponseBuilder(), $request, $errors);
         }
 
         return new JsonResponse($errors, 422);
@@ -98,8 +86,8 @@ trait ProvidesConvenienceMethods
      */
     protected function formatValidationErrors(Validator $validator)
     {
-        if (isset(static::$errorFormatter)) {
-            return call_user_func(static::$errorFormatter, $validator);
+        if ($this->getErrorFormatter()) {
+            return call_user_func($this->getErrorFormatter(), $validator);
         }
 
         return $validator->errors()->getMessages();
@@ -185,5 +173,25 @@ trait ProvidesConvenienceMethods
     protected function getValidationFactory()
     {
         return app('validator');
+    }
+
+    /**
+     * Get a response builder.
+     *
+     * @return callable|null
+     */
+    protected function getResponseBuilder()
+    {
+        return app()->has('routing.responseBuilder') ? app('routing.responseBuilder') : null;
+    }
+
+    /**
+     * Get a error formatter.
+     *
+     * @return callable|null
+     */
+    protected function getErrorFormatter()
+    {
+        return app()->has('routing.errorFormatter') ? app('routing.errorFormatter') : null;
     }
 }

--- a/tests/FullApplicationTest.php
+++ b/tests/FullApplicationTest.php
@@ -485,6 +485,41 @@ class FullApplicationTest extends TestCase
         $this->assertEquals($response->getContent(), '{"name":"Jon"}');
     }
 
+    public function testApplicationCanSetResponseBuilder()
+    {
+        $app = new Application();
+
+        $resp = new Illuminate\Http\JsonResponse([], 422);
+        $app->buildResponseUsing(function ($req, $errors) use ($resp) {
+            return $resp;
+        });
+
+        $app->router->get('/', function (Request $request) {
+            $this->validate($request, ['name' => 'required']);
+        });
+
+        $appResponse = $app->handle(Request::create('/', 'GET'));
+
+        $this->assertSame($resp, $appResponse);
+    }
+
+    public function testApplicationCanSetErrorFormatter()
+    {
+        $app = new Application();
+
+        $app->formatErrorsUsing(function ($validator) {
+            return [count($validator->errors()->getMessages())];
+        });
+
+        $app->router->get('/', function (Request $request) {
+            $this->validate($request, ['name' => 'required']);
+        });
+
+        $response = $app->handle(Request::create('/', 'GET'));
+
+        $this->assertEquals('[1]', $response->getContent());
+    }
+
     public function testRedirectResponse()
     {
         $app = new Application;


### PR DESCRIPTION
If you want to configure the Routing response builder or error formatter, you need to call the `buildResponseUsing` on both the Closure and Controller class to affect both styles of controllers.

```php
$responseBuilder = function() {};

Laravel\Lumen\Routing\Closure::buildResponseUsing($validation_response_builder);
Laravel\Lumen\Routing\Controller::buildResponseUsing($validation_response_builder);
```

Or I just found while I was making this PR, you can actually call the trait's static method as well:

```php
Laravel\Lumen\Routing\ProvidesConvenienceMethods::buildResponseUsing($validation_response_builder);
```

However, this functionality isn't documented in PHP and also isn't very intuitive.

The change this PR makes is that you set the `buildResponseUsing` and `formatErrorsUsing` on the lumen application and the `ProvidesConvenienceMethods` reads from the app instead of static variables.

```php
$app = new Lumen\Application();
$app->buildResponseUsing(function() {});
$app->formatErrorsUsing(function() {});

// instead of

Lumen\Routing\Closure::buildResponseUsing(function() {});
Lumen\Routing\Controller::buildResponseUsing(function() {});
```