### PR TITLE
Add default client in redis configuration

### DIFF
--- a/config/database.php
+++ b/config/database.php
@@ -121,6 +121,8 @@ return [
 
     'redis' => [
 
+        'client' => 'predis',
+
         'cluster' => env('REDIS_CLUSTER', false),
 
         'default' => [


### PR DESCRIPTION
Hi, is it possible to add the default client to redis in the default configuration. for more visibility