### PR TITLE
Keep validate method return only with rule items

### DIFF
--- a/src/Routing/ProvidesConvenienceMethods.php
+++ b/src/Routing/ProvidesConvenienceMethods.php
@@ -3,6 +3,7 @@
 namespace Laravel\Lumen\Routing;
 
 use Closure as BaseClosure;
+use Illuminate\Support\Str;
 use Illuminate\Http\Request;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Validation\Validator;
@@ -64,7 +65,21 @@ trait ProvidesConvenienceMethods
             $this->throwValidationException($request, $validator);
         }
 
-        return $validator->getData();
+        return $this->extractInputFromRules($request, $rules);
+    }
+
+    /**
+     * Get the request input based on the given validation rules.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @param  array  $rules
+     * @return array
+     */
+    protected function extractInputFromRules(Request $request, array $rules)
+    {
+        return $request->only(collect($rules)->keys()->map(function ($rule) {
+            return Str::contains($rule, '.') ? explode('.', $rule)[0] : $rule;
+        })->unique()->toArray());
     }
 
     /**


### PR DESCRIPTION
When I use validate in lumen, it will return all data in request, but laravel only return request data in rules, so change it to keep same with laravel