### PR TITLE
[5.6] Router: Add support for head method

### DIFF
--- a/src/Routing/Router.php
+++ b/src/Routing/Router.php
@@ -392,6 +392,20 @@ class Router
     }
 
     /**
+     * Register a route with the application.
+     *
+     * @param  string  $uri
+     * @param  mixed  $action
+     * @return $this
+     */
+    public function head($uri, $action)
+    {
+        $this->addRoute('HEAD', $uri, $action);
+
+        return $this;
+    }
+
+    /**
      * Get the raw routes for the application.
      *
      * @return array


### PR DESCRIPTION
FastRoute will fall back to GET when a HEAD method is not defined for a route, but there are occasions where a HEAD method may need to be handled separately from a GET route.