### PR TITLE
Add translator alias

### DIFF
--- a/src/Application.php
+++ b/src/Application.php
@@ -818,10 +818,10 @@ class Application extends Container
             'Illuminate\Contracts\Queue\Queue' => 'queue.connection',
             'request' => 'Illuminate\Http\Request',
             'Laravel\Lumen\Routing\Router' => 'router',
+            'Illuminate\Contracts\Translation\Translator' => 'translator',
             'Laravel\Lumen\Routing\UrlGenerator' => 'url',
             'Illuminate\Contracts\Validation\Factory' => 'validator',
             'Illuminate\Contracts\View\Factory' => 'view',
-            'Illuminate\Contracts\Translation\Translator' => 'translator',
         ];
     }
 

--- a/src/Application.php
+++ b/src/Application.php
@@ -821,6 +821,7 @@ class Application extends Container
             'Laravel\Lumen\Routing\UrlGenerator' => 'url',
             'Illuminate\Contracts\Validation\Factory' => 'validator',
             'Illuminate\Contracts\View\Factory' => 'view',
+            'Illuminate\Contracts\Translation\Translator' => 'translator',
         ];
     }
 


### PR DESCRIPTION
Since 5.6 the `Illuminate\Mail\Mailable::send()` requires the Translator to work.

Without an alias to its contract, it breaks the things.