### PR TITLE
[5.6] Add console request for url generation

### DIFF
--- a/src/Console/Kernel.php
+++ b/src/Console/Kernel.php
@@ -5,6 +5,7 @@ namespace Laravel\Lumen\Console;
 use Exception;
 use Throwable;
 use RuntimeException;
+use Illuminate\Http\Request;
 use Laravel\Lumen\Application;
 use Illuminate\Console\Scheduling\Schedule;
 use Illuminate\Console\Application as Artisan;
@@ -52,8 +53,8 @@ class Kernel implements KernelContract
     {
         $this->app = $app;
 
+        $this->setRequestForConsole($this->app);
         $this->app->prepareForConsoleCommand($this->aliases);
-
         $this->defineConsoleSchedule();
     }
 
@@ -202,5 +203,31 @@ class Kernel implements KernelContract
     protected function renderException($output, Exception $e)
     {
         $this->app['Illuminate\Contracts\Debug\ExceptionHandler']->renderForConsole($output, $e);
+    }
+
+    /**
+     * Set the request for url generation.
+     *
+     * @param  \Illuminate\Contracts\Foundation\Application  $app
+     * @return void
+     */
+    protected function setRequestForConsole(Application $app)
+    {
+        $uri = $app->make('config')->get('app.url', env('APP_URL', 'http://localhost'));
+
+        $components = parse_url($uri);
+
+        $server = $_SERVER;
+
+        if (isset($components['path'])) {
+            $server = array_merge($server, [
+                'SCRIPT_FILENAME' => $components['path'],
+                'SCRIPT_NAME' => $components['path'],
+            ]);
+        }
+
+        $app->instance('request', Request::create(
+            $uri, 'GET', [], [], [], $server
+        ));
     }
 }


### PR DESCRIPTION
In a console environment there was no Request object. This caused problems with url generation during testing, and artisan commands.
Hopefully fixes #513 and #667.