### PR TITLE
[5.6] Fix json test with files

### DIFF
--- a/src/Testing/Concerns/MakesHttpRequests.php
+++ b/src/Testing/Concerns/MakesHttpRequests.php
@@ -478,6 +478,7 @@ trait MakesHttpRequests
                 $data[$key] = $value;
             }
         }
+
         return $files;
     }
 }


### PR DESCRIPTION
When call $this->json with file object, files not be included with request.
this changes sync from laravel to make it work.