### PR TITLE
[5.6] Console Kernel: bind request into container only if not already bound

### DIFF
--- a/src/Console/Kernel.php
+++ b/src/Console/Kernel.php
@@ -53,7 +53,7 @@ class Kernel implements KernelContract
     {
         $this->app = $app;
 
-        if (!$this->app->bound('request')) {
+        if (! $this->app->bound('request')) {
             $this->setRequestForConsole($this->app);
         }
 

--- a/src/Console/Kernel.php
+++ b/src/Console/Kernel.php
@@ -53,7 +53,10 @@ class Kernel implements KernelContract
     {
         $this->app = $app;
 
-        $this->setRequestForConsole($this->app);
+        if (!$this->app->bound('request')) {
+            $this->setRequestForConsole($this->app);
+        }
+
         $this->app->prepareForConsoleCommand($this->aliases);
         $this->defineConsoleSchedule();
     }


### PR DESCRIPTION
The change made into #739 bind request into the container regardless if a request has been already bound or not which has for result to give an empty request to my `viaRequest` closure in `AuthServiceProvider` so I'm not able to authenticate any user from the request anymore.

This fix bind the request into the container only if no request has been bound before.