### PR TITLE
Test a job should not be fired by the application

### DIFF
--- a/src/Testing/TestCase.php
+++ b/src/Testing/TestCase.php
@@ -255,7 +255,7 @@ abstract class TestCase extends BaseTestCase
 
 
     /**
-     * Specify a list of jobs that should not be fired by applications.
+     * Specify a list of jobs that should not be fired by application.
      *
      * @param  array|string  $jobs
      * @return $this

--- a/src/Testing/TestCase.php
+++ b/src/Testing/TestCase.php
@@ -253,7 +253,6 @@ abstract class TestCase extends BaseTestCase
         return $this;
     }
 
-
     /**
      * Specify a list of jobs that should not be fired by application.
      *

--- a/src/Testing/TestCase.php
+++ b/src/Testing/TestCase.php
@@ -253,6 +253,34 @@ abstract class TestCase extends BaseTestCase
         return $this;
     }
 
+
+    /**
+     * Specify a list of jobs that should not be fired by applications.
+     *
+     * @param  array|string  $jobs
+     * @return $this
+     */
+    protected function notExpectsJobs($jobs)
+    {
+        $jobs = is_array($jobs) ? $jobs : func_get_args();
+
+        unset($this->app->availableBindings['Illuminate\Contracts\Bus\Dispatcher']);
+
+        $mock = Mockery::mock('Illuminate\Bus\Dispatcher[dispatch]', [$this->app]);
+
+        foreach ($jobs as $job) {
+            $mock->shouldReceive('dispatch')->never()
+                ->with(Mockery::type($job));
+        }
+
+        $this->app->instance(
+            'Illuminate\Contracts\Bus\Dispatcher',
+            $mock
+        );
+
+        return $this;
+    }
+
     /**
      * Mock the job dispatcher so all jobs are silenced and collected.
      *


### PR DESCRIPTION
The pull request includes a new test method which will verify that a job is not expecting by the application. The framework already includes a test method (`expectsJobs($jobs)`) to verify the job is being fired or not but nothing for the testing opposite.