### PR TITLE
[5.6] Fix to use request object when calling requests on testing

### DIFF
--- a/src/Testing/Concerns/MakesHttpRequests.php
+++ b/src/Testing/Concerns/MakesHttpRequests.php
@@ -335,8 +335,10 @@ trait MakesHttpRequests
             $cookies, $files, $server, $content
         );
 
+        $this->app['request'] = Request::createFromBase($symfonyRequest);
+
         return $this->response = $this->app->prepareResponse(
-            $this->app->handle(Request::createFromBase($symfonyRequest))
+            $this->app->handle($this->app['request'])
         );
     }
 


### PR DESCRIPTION
This PR resolves #745 

When making request calls in tests it uses applications (console) request but that has been replaced in this commit c86cc51b88095b0dea06fc0c4d837abfe1264971

PR adds request object to application thats being built when test calls request.