### PR TITLE
[5.6] Added phpdbg to runningInConsole to bring in line with Laravel

### DIFF
--- a/src/Application.php
+++ b/src/Application.php
@@ -734,7 +734,7 @@ class Application extends Container
      */
     public function runningInConsole()
     {
-        return php_sapi_name() == 'cli';
+        return php_sapi_name() === 'cli' || php_sapi_name() === 'phpdbg';
     }
 
     /**


### PR DESCRIPTION
The runningInConsole functions of Lumen are Laravel are currently different to each other. This means PHPUnit code coverage using phpdbg cannot be achieved with Lumen, but can with Laravel.

Please refer to https://github.com/laravel/framework/blob/5.6/src/Illuminate/Foundation/Application.php#L518 to see this functionality in Laravel 5.6.