### PR TITLE
Fix expectsEvents method to work

### DIFF
--- a/src/Testing/TestCase.php
+++ b/src/Testing/TestCase.php
@@ -184,6 +184,8 @@ abstract class TestCase extends BaseTestCase
     {
         $events = is_array($events) ? $events : func_get_args();
 
+        unset($this->app->availableBindings['events']);
+
         $mock = Mockery::spy('Illuminate\Contracts\Events\Dispatcher');
 
         $mock->shouldReceive('fire')->andReturnUsing(function ($called) use (&$events) {


### PR DESCRIPTION
Before this PR, `Laravel\Lumen\Testing\TestCase::expectsEvents()` does not work well.
It seems to be caused by what the mock was not inject to container.

This PR inject mock to container to fix that :)