### PR TITLE
Add Missing Testing Traits

### DIFF
--- a/src/Testing/WithoutEvents.php
+++ b/src/Testing/WithoutEvents.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Laravel\Lumen\Testing;
+
+use Exception;
+
+trait WithoutEvents
+{
+    /**
+     * Prevent all event handles from being executed.
+     *
+     * @throws \Exception
+     */
+    public function disableEventsForAllTests()
+    {
+        if (method_exists($this, 'withoutEvents')) {
+            $this->withoutEvents();
+        } else {
+            throw new Exception('Unable to disable events. ApplicationTrait not used.');
+        }
+    }
+}

--- a/src/Testing/WithoutMiddleware.php
+++ b/src/Testing/WithoutMiddleware.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Laravel\Lumen\Testing;
+
+use Exception;
+
+trait WithoutMiddleware
+{
+    /**
+     * Prevent all middleware from being executed for this test class.
+     *
+     * @throws \Exception
+     */
+    public function disableMiddlewareForAllTests()
+    {
+        if (method_exists($this, 'withoutMiddleware')) {
+            $this->withoutMiddleware();
+        } else {
+            throw new Exception('Unable to disable middleware. MakesHttpRequests trait not used.');
+        }
+    }
+}


### PR DESCRIPTION
The `WithoutEvents` and `WithoutMiddleware` traits are referenced in [`Laravel\Lumen\Testing\TestCase`](https://github.com/laravel/lumen-framework/blob/5.6/src/Testing/TestCase.php#L90-L96) but the traits themselves are not included in the Lumen Framework.