### PR TITLE
Add `dispatch` method as a mock to the Event Dispatcher in `TestCase`

### DIFF
--- a/src/Testing/TestCase.php
+++ b/src/Testing/TestCase.php
@@ -186,7 +186,7 @@ abstract class TestCase extends BaseTestCase
 
         $mock = Mockery::spy('Illuminate\Contracts\Events\Dispatcher');
 
-        $mock->shouldReceive('fire')->andReturnUsing(function ($called) use (&$events) {
+        $mock->shouldReceive('fire', 'dispatch')->andReturnUsing(function ($called) use (&$events) {
             foreach ($events as $key => $event) {
                 if ((is_string($called) && $called === $event) ||
                     (is_string($called) && is_subclass_of($called, $event)) ||

--- a/src/Testing/TestCase.php
+++ b/src/Testing/TestCase.php
@@ -218,7 +218,7 @@ abstract class TestCase extends BaseTestCase
     {
         $mock = Mockery::mock('Illuminate\Contracts\Events\Dispatcher');
 
-        $mock->shouldReceive('fire');
+        $mock->shouldReceive('fire', 'dispatch');
 
         $this->app->instance('events', $mock);
 


### PR DESCRIPTION
## Problem
When using the `WithoutEvents` test trait or directly calling the `$this->withoutEvents()` within a test, a `BadMethodCallException` is thrown.

From the logs:

>...BadMethodCallException(code: 0): Method Mockery_0_Illuminate_Contracts_Events_Dispatcher::dispatch() does not exist on this mock object at...

## Background
Calling `event()` within your application executes the `Illuminate\Events\Dispatcher@fire`, while internal events executed by the framework itself call the `Illuminate\EventsDispatcher@dispatch` method. When mocking the dispatcher, currently the the `TestCase@withoutEvents` method only mocks the `fire` method, therefore when internal framework events are fired using the `dispatch` method, the method isn't mocked and therefore throws an exception.

## Solution

Update the mock object to mock the `dispatch` method: `$mock->shouldReceive('fire', 'dispatch');`.

Staying inline with Laravel 5.6, `TestCase@expectsEvents` has been updated to spy on `dispatch` as well. This will also help ensure that internal framework events are not actually executed during testing.