### PR TITLE
Change invalid annotation of method

### DIFF
--- a/src/Exceptions/Handler.php
+++ b/src/Exceptions/Handler.php
@@ -78,7 +78,7 @@ class Handler implements ExceptionHandler
      *
      * @param  \Illuminate\Http\Request  $request
      * @param  \Exception  $e
-     * @return \Illuminate\Http\Response
+     * @return \Symfony\Component\HttpFoundation\Response
      */
     public function render($request, Exception $e)
     {


### PR DESCRIPTION
Hi! 
I understand what my PR is not so critical, but maybe it will interesting for you.
In file src/Exceptions/Handler.php we can see, that method render return \Illuminate\Http\Response
But in last version of Illuminate interface of Exception Handler we can see, that return value is \Symfony\Component\HttpFoundation\Response. 
I think need use \Symfony\Component\HttpFoundation\Response in annotation, because \Illuminate\Http\Response doesn't support \Illuminate\Http\JsonResponse, and Lumen is framework for api, handler must be able return JsonResponse.
Thank you for attention.