### PR TITLE
Bind the app environment as 'env'

### DIFF
--- a/src/Application.php
+++ b/src/Application.php
@@ -104,6 +104,8 @@ class Application extends Container
 
         $this->instance('path', $this->path());
 
+        $this->instance('env', $this->environment());
+
         $this->registerContainerAliases();
     }
 


### PR DESCRIPTION
The new `LogManager` [expects the `env` binding to exist](https://github.com/laravel/framework/blob/6a88b98e58f92ca1928175291ca0259db3704db0/src/Illuminate/Log/LogManager.php#L393).  If it isn't set everything get's logged as 'production', like this:

```
[2018-05-24 20:46:16] production.INFO: hello world
```

This PR adds the `env` binding when the container is bootstrapped so the logs return the correct environment.

```
[2018-05-24 20:46:53] local.INFO: hello world
```