### PR TITLE
efresh of migrate in DatabaseMigrations

### DIFF
--- a/src/Testing/DatabaseMigrations.php
+++ b/src/Testing/DatabaseMigrations.php
@@ -11,7 +11,7 @@ trait DatabaseMigrations
      */
     public function runDatabaseMigrations()
     {
-        $this->artisan('migrate');
+        $this->artisan('migrate:fresh');
 
         $this->beforeApplicationDestroyed(function () {
             $this->artisan('migrate:rollback');


### PR DESCRIPTION
I used the refresh command instead of the migrate command (like in laravel/framework) to revert db inserts and deletes in tests.