### PR TITLE
[5.6] Fixes condition to json_decode responseData

### DIFF
--- a/src/Testing/Concerns/MakesHttpRequests.php
+++ b/src/Testing/Concerns/MakesHttpRequests.php
@@ -237,7 +237,7 @@ trait MakesHttpRequests
             return $this->seeJson();
         }
 
-        if (! $responseData) {
+        if (!is_array($responseData)) {
             $responseData = json_decode($this->response->getContent(), true);
         }
 

--- a/src/Testing/Concerns/MakesHttpRequests.php
+++ b/src/Testing/Concerns/MakesHttpRequests.php
@@ -237,7 +237,7 @@ trait MakesHttpRequests
             return $this->seeJson();
         }
 
-        if (!is_array($responseData)) {
+        if (! is_array($responseData)) {
             $responseData = json_decode($this->response->getContent(), true);
         }
 


### PR DESCRIPTION
PHPUnit\Framework\Exception: Argument #2 (No Value) of PHPUnit\Framework\Assert::assertArrayHasKey() must be a array or ArrayAccess