### PR TITLE
[5.6] Fix memory leak for tests

### DIFF
--- a/src/Application.php
+++ b/src/Application.php
@@ -793,6 +793,29 @@ class Application extends Container
 
         throw new RuntimeException('Unable to detect application namespace.');
     }
+    
+    /**
+     * Flush the container of all bindings and resolved instances.
+     *
+     * @return void
+     */
+    public function flush()
+    {
+        parent::flush();
+        $this->reboundCallbacks = [];
+        $this->resolvingCallbacks = [];
+        $this->afterResolvingCallbacks = [];
+        $this->middleware = [];
+        $this->routeMiddleware = [];
+        $this->currentRoute = [];
+        $this->availableBindings = [];
+        $this->ranServiceBinders = [];
+        $this->loadedProviders = [];
+        $this->loadedConfigurations = [];
+        $this->router = null;
+        $this->dispatcher = null;
+        static::$instance = null;
+    }
 
     /**
      * Register the core container aliases.

--- a/src/Application.php
+++ b/src/Application.php
@@ -793,7 +793,7 @@ class Application extends Container
 
         throw new RuntimeException('Unable to detect application namespace.');
     }
-    
+
     /**
      * Flush the container of all bindings and resolved instances.
      *


### PR DESCRIPTION
Same problem as described here:
https://github.com/laravel/framework/issues/21015

For me, the effects look as follows:
Before:
```
Time: 8.16 minutes, Memory: 510.00MB

OK (1112 tests, 3677 assertions)
```
After:
```
Time: 8.08 minutes, Memory: 140.00MB

OK (1112 tests, 3677 assertions)
```