### PR TITLE
[5.6] Fix multiple request instances in the container during integration test

### DIFF
--- a/src/Testing/Concerns/MakesHttpRequests.php
+++ b/src/Testing/Concerns/MakesHttpRequests.php
@@ -335,10 +335,10 @@ trait MakesHttpRequests
             $cookies, $files, $server, $content
         );
 
-        $this->app['request'] = Request::createFromBase($symfonyRequest);
+        $this->app[Request::class] = Request::createFromBase($symfonyRequest);
 
         return $this->response = $this->app->prepareResponse(
-            $this->app->handle($this->app['request'])
+            $this->app->handle($this->app[Request::class])
         );
     }
 


### PR DESCRIPTION
This PR resolves [#788](https://github.com/laravel/lumen-framework/issues/788)

PR resolves the issue when the request instance that is modified by middleware is not the same request instance during the integration test.