### PR TITLE
Add the routesAreCached method, so Lumen won't throw a "Call to undef…

### DIFF
--- a/src/Application.php
+++ b/src/Application.php
@@ -820,6 +820,16 @@ class Application extends Container
     }
 
     /**
+     * Determine if the application routes are cached.
+     *
+     * @return bool
+     */
+    public function routesAreCached()
+    {
+        return false;
+    }
+
+    /**
      * Register the core container aliases.
      *
      * @return void


### PR DESCRIPTION
I made this pull request to fix the "Call to undefined method" regarding the `routesAreCached` method. It seems like route caching is not supported in Lumen, that's why i made it return false on default.

#746 