### PR TITLE
[5.6] Feature/fix route parameter

### DIFF
--- a/src/Concerns/RoutesRequests.php
+++ b/src/Concerns/RoutesRequests.php
@@ -8,6 +8,7 @@ use Throwable;
 use FastRoute\Dispatcher;
 use Illuminate\Support\Str;
 use Illuminate\Http\Request;
+use Laravel\Lumen\Http\Request as ExtendedRequest;
 use Illuminate\Http\Response;
 use Laravel\Lumen\Routing\Pipeline;
 use Illuminate\Contracts\Support\Responsable;
@@ -180,7 +181,7 @@ trait RoutesRequests
     protected function parseIncomingRequest($request)
     {
         if (! $request) {
-            $request = Request::capture();
+            $request = ExtendedRequest::capture();
         }
 
         $this->instance(Request::class, $this->prepareRequest($request));

--- a/src/Http/Request.php
+++ b/src/Http/Request.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Laravel\Lumen\Http;
+
+use Illuminate\Http\Request as BaseRequest;
+
+class Request extends BaseRequest
+{
+
+    /**
+     * Get the route handling the request.
+     *
+     * @param  string|null  $param
+     *
+     * @return \Illuminate\Routing\Route|object|string
+     */
+    public function route($param = null)
+    {
+        $route = call_user_func($this->getRouteResolver());
+
+        if (is_null($route) || is_null($param)) {
+            return $route;
+        }
+
+        return Arr::get($route[2], $param);
+    }
+
+}

--- a/src/Http/Request.php
+++ b/src/Http/Request.php
@@ -3,6 +3,7 @@
 namespace Laravel\Lumen\Http;
 
 use Illuminate\Http\Request as BaseRequest;
+use Illuminate\Support\Arr;
 
 class Request extends BaseRequest
 {


### PR DESCRIPTION
I made this pull request, to fix the `Call to a member function parameter() on array` error. This would occur when you called the `route` method on the `Illuminate\http\Request` class in Lumen. I tried to follow the advice in this pull request: #11873

#291
#650
#484
#119 
#685 