### PR TITLE
[5.6] Fix missing parameter function on Request.

### DIFF
--- a/src/Concerns/RoutesRequests.php
+++ b/src/Concerns/RoutesRequests.php
@@ -4,6 +4,7 @@ namespace Laravel\Lumen\Concerns;
 
 use Closure;
 use Exception;
+use Laravel\Lumen\Http\Request as LumenRequest;
 use Throwable;
 use FastRoute\Dispatcher;
 use Illuminate\Support\Str;
@@ -180,7 +181,7 @@ trait RoutesRequests
     protected function parseIncomingRequest($request)
     {
         if (! $request) {
-            $request = Request::capture();
+            $request = LumenRequest::capture();
         }
 
         $this->instance(Request::class, $this->prepareRequest($request));

--- a/src/Http/Request.php
+++ b/src/Http/Request.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Laravel\Lumen\Http;
+
+use Illuminate\Http\Request as BaseRequest;
+use Illuminate\Support\Arr;
+
+class Request extends BaseRequest
+{
+    /**
+     * Get the route handling the request.
+     *
+     * @param  string|null  $param
+     *
+     * @return array|string
+     */
+    public function route($param = null)
+    {
+        $route = call_user_func($this->getRouteResolver());
+
+        if (is_null($route) || is_null($param)) {
+            return $route;
+        }
+
+        return Arr::get($route[2], $param);
+    }
+}

--- a/tests/FullApplicationTest.php
+++ b/tests/FullApplicationTest.php
@@ -3,6 +3,7 @@
 use Mockery as m;
 use Illuminate\Http\Request;
 use Laravel\Lumen\Application;
+use Laravel\Lumen\Http\Request as LumenRequest;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\Request as SymfonyRequest;
 
@@ -70,6 +71,21 @@ class FullApplicationTest extends TestCase
 
         $this->assertEquals(200, $response->getStatusCode());
         $this->assertEquals('12', $response->getContent());
+    }
+
+    public function testLumenRequestWithParameters()
+    {
+        $app = new Application;
+
+        $app->router->get('/foo/{bar}/{baz}', function ($bar, $baz) {
+            return response($bar.$baz);
+        });
+
+        $app->handle(LumenRequest::create('/foo/1/test', 'GET'));
+        $request = $app['Illuminate\Http\Request'];
+
+        $this->assertEquals('1', $request->route('bar'));
+        $this->assertEquals('test', $request->route('baz'));
     }
 
     public function testCallbackRouteWithDefaultParameter()


### PR DESCRIPTION
This is a follow up on my closed Pull Request #793. I made some adjustments and i've added a test.

> I made this pull request, to fix the Call to a member function parameter() on array error. This would occur when you called the route method on the Illuminate\http\Request class in Lumen. I tried to follow the advice in this pull request: #11873

#291
#650
#484
#119
#685