### PR TITLE
[5.7] The url helper generates the wrong url, when used in a queue.

### DIFF
--- a/src/Console/Kernel.php
+++ b/src/Console/Kernel.php
@@ -53,7 +53,7 @@ class Kernel implements KernelContract
     {
         $this->app = $app;
 
-        if (! $this->app->bound('request')) {
+        if ($this->app->runningInConsole()) {
             $this->setRequestForConsole($this->app);
         }
 


### PR DESCRIPTION
If the url helper or generator is used in a command line based request, it will return the wrong url. This problem occured in Laravel a while ago. Someone fixed this problem and the fix was also implemented in Lumen. ( laravel/framework#14139) 

The fix was implemented in the `kernel.php` in the `Console` directory. The fix currently is implemented like this:

```php
if (! $this->app->bound('request')) {
    $this->setRequestForConsole($this->app);
}
```

The `setRequestForConsole`, however, will never be called because the request is bound on every request. Console or not. The request alias is registered in the `registerContainerAliases` method in the `Application`. This method is called in the `bootstrapContainer` method which is called in the constructor of `Application` class. And the `Application` class will always be instantiated.

That's why i replaced the conditional with a conditional which checks whether the request runs in the console. That way we can determine whether or not to use the `setRequestForConsole` method.

#791
#768