### PR TITLE
[5.7] Boot the application in the testing environment.

### DIFF
--- a/src/Testing/TestCase.php
+++ b/src/Testing/TestCase.php
@@ -54,6 +54,7 @@ abstract class TestCase extends BaseTestCase
         Facade::clearResolvedInstances();
 
         $this->app = $this->createApplication();
+        $this->app->boot();
     }
 
     /**


### PR DESCRIPTION
Due to some new changes in Lumen, the application only boots within the `RoutesRequests` class. This pull requests ensures that the app will also boot when it's in testing mode.

#808
#806 