### PR TITLE
[5.7] Route helper optional params

### DIFF
--- a/src/Routing/UrlGenerator.php
+++ b/src/Routing/UrlGenerator.php
@@ -254,6 +254,7 @@ class UrlGenerator
         }
 
         $uri = $this->app->router->namedRoutes[$name];
+        $uri = str_replace(['[', ']'], '', $uri);
 
         $parameters = $this->formatParametersForUrl($parameters);
 
@@ -261,7 +262,6 @@ class UrlGenerator
             return isset($parameters[$m[1]]) ? array_pull($parameters, $m[1]) : $m[0];
         }, $uri);
 
-        $uri = str_replace(['[', ']'], '', $uri);
         $uri = $this->to($uri, [], $secure);
 
         if (! empty($parameters)) {

--- a/src/Routing/UrlGenerator.php
+++ b/src/Routing/UrlGenerator.php
@@ -261,6 +261,7 @@ class UrlGenerator
             return isset($parameters[$m[1]]) ? array_pull($parameters, $m[1]) : $m[0];
         }, $uri);
 
+        $uri = str_replace(['[', ']'], '', $uri);
         $uri = $this->to($uri, [], $secure);
 
         if (! empty($parameters)) {

--- a/tests/FullApplicationTest.php
+++ b/tests/FullApplicationTest.php
@@ -285,10 +285,19 @@ class FullApplicationTest extends TestCase
             //
         }]);
 
+        $app->router->get('/test/{required}[/{optional}]', ['as' => 'test', function () {
+            //
+        }]);
+
         $this->assertEquals('http://lumen.laravel.com/something', url('something'));
         $this->assertEquals('http://lumen.laravel.com/foo-bar', route('foo'));
         $this->assertEquals('http://lumen.laravel.com/foo-bar/1/2', route('bar', ['baz' => 1, 'boom' => 2]));
         $this->assertEquals('http://lumen.laravel.com/foo-bar?baz=1&boom=2', route('foo', ['baz' => 1, 'boom' => 2]));
+
+        $this->assertEquals('http://lumen.laravel.com/test/nice/parameters', route('test', [
+            'required' => 'nice',
+            'optional' => 'parameters'
+        ]));
     }
 
     public function testGeneratingUrlsForRegexParameters()

--- a/tests/FullApplicationTest.php
+++ b/tests/FullApplicationTest.php
@@ -296,7 +296,7 @@ class FullApplicationTest extends TestCase
 
         $this->assertEquals('http://lumen.laravel.com/test/nice/parameters', route('test', [
             'required' => 'nice',
-            'optional' => 'parameters'
+            'optional' => 'parameters',
         ]));
     }
 


### PR DESCRIPTION
When generating a url with optional parameters in Lumen, the square brackets will not be removed from the url. The generator only replaces the place holder between the curly brackets. 

This PR removes the square brackets from the url, while it's being generated.

Result before fix:

`url/[paramvalue]`

Result after fix:

`url/paramvalue`

#539 