### PR TITLE
Correct phpdoc of JsonResponse data to mixed type

### DIFF
--- a/src/Http/ResponseFactory.php
+++ b/src/Http/ResponseFactory.php
@@ -25,7 +25,7 @@ class ResponseFactory
     /**
      * Return a new JSON response from the application.
      *
-     * @param  string|array  $data
+     * @param  mixed  $data
      * @param  int    $status
      * @param  array  $headers
      * @param  int    $options


### PR DESCRIPTION
The phpdoc currently specifies either string or array, but the data parameter of json can be a variety of types in lumen/laravel.

See also upstream parameter definition in: https://github.com/laravel/framework/blob/5.3/src/Illuminate/Http/JsonResponse.php#L23
and consuming implementation: https://github.com/laravel/framework/blob/5.3/src/Illuminate/Http/JsonResponse.php#L56

This helps code to pass in larastan.