### PR TITLE
Include Symfony VarDumper component

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -40,7 +40,8 @@
         "dragonmantank/cron-expression": "^2.0",
         "nikic/fast-route": "^1.3",
         "symfony/http-kernel": "^4.1",
-        "symfony/http-foundation": "^4.1"
+        "symfony/http-foundation": "^4.1",
+        "symfony/var-dumper": "^4.1"
     },
     "require-dev": {
         "mockery/mockery": "^1.0",


### PR DESCRIPTION
After https://github.com/illuminate/support/commit/98cf3233c2e4a54c9aeba661e0ec40ccc3285dc0 the `dd` helper no longer exists in Lumen.

This pull requests adds the `symfony/var-dumper` to the framework's `composer.json` and brings the helper back.