### PR TITLE
Change Request instance for responses implementing Responsable interface

### DIFF
--- a/src/Concerns/RoutesRequests.php
+++ b/src/Concerns/RoutesRequests.php
@@ -425,7 +425,7 @@ trait RoutesRequests
     public function prepareResponse($response)
     {
         if ($response instanceof Responsable) {
-            $response = $response->toResponse(Request::capture());
+            $response = $response->toResponse(app(Request::class));
         }
 
         if ($response instanceof PsrResponseInterface) {

--- a/tests/FullApplicationTest.php
+++ b/tests/FullApplicationTest.php
@@ -257,20 +257,19 @@ class FullApplicationTest extends TestCase
         $this->assertEquals(405, $response->getStatusCode());
     }
 
-    public function testRequestInResponse()
+    public function testResponsableInterface()
     {
         $app = new Application;
 
         $app->router->get('/foo/{foo}', function () {
-            return new ResourceResponse;
+            return new ResponsableResponse;
         });
 
-        $request = Request::create('/foo/1', 'GET');
+        $request = Request::create('/foo/999', 'GET');
         $response = $app->handle($request);
 
-        $this->assertEquals(1, $request->route('foo'));
-        $this->assertInternalType('array', $response->original);
-        $this->assertEquals(['foo' => 1], $response->original);
+        $this->assertEquals(999, $request->route('foo'));
+        $this->assertEquals(999, $response->original);
     }
 
     public function testUncaughtExceptionResponse()
@@ -788,10 +787,10 @@ class LumenTestTerminateMiddleware
     }
 }
 
-class ResourceResponse implements \Illuminate\Contracts\Support\Responsable
+class ResponsableResponse implements \Illuminate\Contracts\Support\Responsable
 {
     public function toResponse($request)
     {
-        return ['foo' => $request->route('foo')];
+        return $request->route('foo');
     }
 }

--- a/tests/FullApplicationTest.php
+++ b/tests/FullApplicationTest.php
@@ -257,6 +257,22 @@ class FullApplicationTest extends TestCase
         $this->assertEquals(405, $response->getStatusCode());
     }
 
+    public function testRequestInResponse()
+    {
+        $app = new Application;
+
+        $app->router->get('/foo/{foo}', function () {
+            return new ResourceResponse;
+        });
+
+        $request = Request::create('/foo/1', 'GET');
+        $response = $app->handle($request);
+
+        $this->assertEquals(1, $request->route('foo'));
+        $this->assertInternalType('array', $response->original);
+        $this->assertEquals(['foo' => 1], $response->original);
+    }
+
     public function testUncaughtExceptionResponse()
     {
         $app = new Application;
@@ -769,5 +785,13 @@ class LumenTestTerminateMiddleware
     public function terminate($request, Illuminate\Http\Response $response)
     {
         $response->setContent('TERMINATED');
+    }
+}
+
+class ResourceResponse implements \Illuminate\Contracts\Support\Responsable
+{
+    public function toResponse($request)
+    {
+        return ['foo' => $request->route('foo')];
     }
 }


### PR DESCRIPTION
> This PR fix #667.

### Description
When testing and making a request to a specific route, inside the Controller action, using the method injection for Request, I get all the information I need:

```php
public function login(Request $request) // $request OK
```

But inside the `Resource` object, in all methods I receive it as a parameter, like `toArray($request)` or `with($request)`, this `$request` object is empty, no route information, no parameters, no path, nothing.

Then I have to get the request again from the service container:

```php
public function with($request) // empty
{
    $request = app(Request::class); // correct

    return $request->is('auth/login') && $this->jwtToken ?
        ['token' => $this->jwtToken] : [];
}
```

### Solution

When implementing the `Responsable` interface we send a new request instance by using `Request::capture()`.

This PR changes this request instance to the same in the service container, allowing you to receive the correct instance in the `toResponse($request)` method, for example.