### PR TITLE
Using migrate:fresh instead of migrate for DatabaseMigrations

### DIFF
--- a/src/Testing/DatabaseMigrations.php
+++ b/src/Testing/DatabaseMigrations.php
@@ -11,7 +11,7 @@ trait DatabaseMigrations
      */
     public function runDatabaseMigrations()
     {
-        $this->artisan('migrate');
+        $this->artisan('migrate:fresh');
 
         $this->beforeApplicationDestroyed(function () {
             $this->artisan('migrate:rollback');


### PR DESCRIPTION
**Issue:**
As described in issue #775  currently the DatabaseMigrations trait doesn't revert database migrations after a test correctly. It just rolls back the last migration so after the first test the database is populated and following tests might not work.

**Fix:**
I replaced the 'migrate' command with 'migrate:fresh' so the database will be fresh before each test.
This is also done in [PR in laravel](https://github.com/laravel/framework/pull/20090).

I think this can break tests although I don't know how the current implementation is working for someone.

Also, I don't know if the rollback after the test would still be necessary.