### PR TITLE
[5.8] Removed obsolete catch

### DIFF
--- a/src/Concerns/RoutesRequests.php
+++ b/src/Concerns/RoutesRequests.php
@@ -166,8 +166,6 @@ trait RoutesRequests
                     $this->createDispatcher()->dispatch($method, $pathInfo)
                 );
             });
-        } catch (Exception $e) {
-            return $this->prepareResponse($this->sendExceptionToHandler($e));
         } catch (Throwable $e) {
             return $this->prepareResponse($this->sendExceptionToHandler($e));
         }

--- a/src/Concerns/RoutesRequests.php
+++ b/src/Concerns/RoutesRequests.php
@@ -3,7 +3,6 @@
 namespace Laravel\Lumen\Concerns;
 
 use Closure;
-use Exception;
 use Throwable;
 use FastRoute\Dispatcher;
 use Illuminate\Support\Str;


### PR DESCRIPTION
All exceptions implement Throwable interface thus given catch statement is obsolete.