### PR TITLE
[5.7] Make sure the response uses the right HTTP protocol.

### DIFF
--- a/src/Concerns/RoutesRequests.php
+++ b/src/Concerns/RoutesRequests.php
@@ -424,8 +424,10 @@ trait RoutesRequests
      */
     public function prepareResponse($response)
     {
+        $request = app(Request::class);
+
         if ($response instanceof Responsable) {
-            $response = $response->toResponse(app(Request::class));
+            $response = $response->toResponse($request);
         }
 
         if ($response instanceof PsrResponseInterface) {
@@ -436,7 +438,7 @@ trait RoutesRequests
             $response = $response->prepare(Request::capture());
         }
 
-        return $response;
+        return $response->prepare($request);
     }
 
     /**


### PR DESCRIPTION
Lumen's `prepareResponse` returns the wrong HTTP protocol because the `prepare` method is not called. This PR prepares the reponse, so it will return the right protocol.

#449 