### PR TITLE
[5.7] Set the application url when running tests.

### DIFF
--- a/src/Testing/TestCase.php
+++ b/src/Testing/TestCase.php
@@ -55,6 +55,8 @@ abstract class TestCase extends BaseTestCase
 
         $this->app = $this->createApplication();
 
+        $this->app->make('url')->forceRootUrl(env('APP_URL', 'http://localhost/'));
+
         $this->app->boot();
     }
 


### PR DESCRIPTION
When running tests, the application will boot through the console and will therefore not have a base url. This issue was fixed for regular commands in the kernel. The kernel, however, will never be instantiated when running tests, because it will boot the application in the regular way.

This PR sest the root url of the url generator to the APP_KEY environment value when Lumen boots in the testing environment.

#513 