### PR TITLE
Dont overwrite container bindings that have already been bound

### DIFF
--- a/src/Application.php
+++ b/src/Application.php
@@ -249,7 +249,8 @@ class Application extends Container
     {
         $abstract = $this->getAlias($abstract);
 
-        if (array_key_exists($abstract, $this->availableBindings) &&
+        if (! $this->bound($abstract) &&
+            array_key_exists($abstract, $this->availableBindings) &&
             ! array_key_exists($this->availableBindings[$abstract], $this->ranServiceBinders)) {
             $this->{$method = $this->availableBindings[$abstract]}();
 

--- a/tests/FullApplicationTest.php
+++ b/tests/FullApplicationTest.php
@@ -666,6 +666,20 @@ class FullApplicationTest extends TestCase
         $this->assertArrayHasKey('hello.world', $app->router->namedRoutes);
         $this->assertEquals('/world', $app->router->namedRoutes['hello.world']);
     }
+
+    public function testContainerBindingsAreNotOverwritten()
+    {
+        $app = new Application();
+
+        $mock = m::mock(Illuminate\Bus\Dispatcher::class);
+
+        $app->instance(Illuminate\Contracts\Bus\Dispatcher::class, $mock);
+
+        $this->assertSame(
+            $mock,
+            $app->make(Illuminate\Contracts\Bus\Dispatcher::class)
+        );
+    }
 }
 
 class LumenTestService


### PR DESCRIPTION
This PR fixes the underlying issue that caused #207 and #416.  I have also seen this cause issues with [other packages](https://github.com/laravel-doctrine/orm/blob/5a004509adccc2cfc2143df6101852e2fab4a048/src/DoctrineServiceProvider.php#L96).  The specific example of `expectsJobs` was fixed by 16a452a but the underlying issue still exists.

If you register your own binding for something in [the availableBindings array](https://github.com/laravel/lumen-framework/blob/ad953771b534b4c1d01f1a3d84353428addcb270/src/Application.php#L906) before it's been resolved at least once, when you go to resolve it Lumen calls the service binder method and overwrites your binding.

To prevent this we can check if the binding has already been bound and if so we won't run the service binder this time.

The overhead is pretty minimal since `Container::bound` is only 1-3 `isset` checks.  I don't think this will cause any issues since there is no reason to run the service binder if the class you are resolving is already bound.