### PR TITLE
[5.7] Don't unnecessarily unset available bindings

### DIFF
--- a/src/Testing/TestCase.php
+++ b/src/Testing/TestCase.php
@@ -241,8 +241,6 @@ abstract class TestCase extends BaseTestCase
     {
         $jobs = is_array($jobs) ? $jobs : func_get_args();
 
-        unset($this->app->availableBindings['Illuminate\Contracts\Bus\Dispatcher']);
-
         $mock = Mockery::mock('Illuminate\Bus\Dispatcher[dispatch]', [$this->app]);
 
         foreach ($jobs as $job) {
@@ -264,8 +262,6 @@ abstract class TestCase extends BaseTestCase
      */
     protected function withoutJobs()
     {
-        unset($this->app->availableBindings['Illuminate\Contracts\Bus\Dispatcher']);
-
         $mock = Mockery::mock('Illuminate\Bus\Dispatcher[dispatch]', [$this->app]);
 
         $mock->shouldReceive('dispatch')->andReturnUsing(function ($dispatched) {

--- a/tests/FullApplicationTest.php
+++ b/tests/FullApplicationTest.php
@@ -290,7 +290,6 @@ class FullApplicationTest extends TestCase
     {
         $app = new Application;
         $app->instance('request', Request::create('http://lumen.laravel.com', 'GET'));
-        unset($app->availableBindings['request']);
 
         $app->router->get('/foo-bar', ['as' => 'foo', function () {
             //
@@ -310,7 +309,6 @@ class FullApplicationTest extends TestCase
     {
         $app = new Application;
         $app->instance('request', Request::create('http://lumen.laravel.com', 'GET'));
-        unset($app->availableBindings['request']);
 
         $app->router->get('/foo-bar', ['as' => 'foo', function () {
             //


### PR DESCRIPTION
This was a workaround and is not necessary since 56277d4 was merged.