### PR TITLE
[5.7] Allow generating URLs with optional parameters

### DIFF
--- a/src/Routing/UrlGenerator.php
+++ b/src/Routing/UrlGenerator.php
@@ -257,6 +257,14 @@ class UrlGenerator
 
         $parameters = $this->formatParametersForUrl($parameters);
 
+        $uri = preg_replace_callback('/\[([^{]*)\{?(.*?)(:.*?)?(\{[0-9,]+\})?\}?([^}]*)\]$/', function ($m) use (&$parameters) {
+            if (! isset($parameters[$m[2]])) {
+                return '';
+            }
+
+            return $m[1].array_pull($parameters, $m[2]).$m[5];
+        }, $uri);
+
         $uri = preg_replace_callback('/\{(.*?)(:.*?)?(\{[0-9,]+\})?\}/', function ($m) use (&$parameters) {
             return isset($parameters[$m[1]]) ? array_pull($parameters, $m[1]) : $m[0];
         }, $uri);

--- a/tests/FullApplicationTest.php
+++ b/tests/FullApplicationTest.php
@@ -334,6 +334,30 @@ class FullApplicationTest extends TestCase
         $this->assertEquals('http://lumen.laravel.com/foo-bar/5', route('boom', ['baz' => 5]));
     }
 
+    public function testGeneratingUrlsForOptionalParameters()
+    {
+        $app = new Application;
+        $app->instance('request', Request::create('http://lumen.laravel.com', 'GET'));
+
+        $app->router->get('/users[/{id:\d+}]', ['as' => 'users', function () {
+            //
+        }]);
+
+        $app->router->get('/users[/{id:\d+}/profile]', ['as' => 'profile', function () {
+            //
+        }]);
+
+        $app->router->get('/foo[bar]', ['as' => 'foo', function () {
+            //
+        }]);
+
+        $this->assertEquals('http://lumen.laravel.com/users', route('users'));
+        $this->assertEquals('http://lumen.laravel.com/users/1', route('users', ['id' => 1]));
+        $this->assertEquals('http://lumen.laravel.com/users/1/profile', route('profile', ['id' => 1]));
+        $this->assertEquals('http://lumen.laravel.com/users', route('profile'));
+        $this->assertEquals('http://lumen.laravel.com/foo', route('foo'));
+    }
+
     public function testRegisterServiceProvider()
     {
         $app = new Application;


### PR DESCRIPTION
This PR makes it possible to generate routes for URLs with optional parameters.  Resolves #539.

To make this possible I added a second `preg_replace_callback` that replaces the optional part of the route.  I'm pretty sure it's not possible to do this with a single regex (Nikic said the same thing [here](https://github.com/nikic/FastRoute/issues/66#issuecomment-130395124)).

The regex is pretty dense so I will attempt to briefly summarize it.  You can view an example on [regexr](https://regexr.com/41jvr).

Unlike required parameters optional parameters might have non dynamic segments before and after, i.e. `/{id:\d+}/profile]`.  This is the reason capture groups 1 and 5 are added to the replacement for capture group 2.

It's also possible for an optional segment to not have any parameters, i.e. `/foo[bar]`.  In this case it's not clear if we should generate `/foobar` or `/foo`.  I went with the shorter URL.

We need to match this optional segment so we can remove it, but we don't want to match the square brackets inside a parameter, i.e. `/users/{id:[0-9]+}`.  Luckily you can only have an optional parameters in the trailing position so we can use `$` instead of a negative lookahead.