### PR TITLE
[5.7] Add support for optional parameters in the route generator.

### DIFF
--- a/src/Routing/UrlGenerator.php
+++ b/src/Routing/UrlGenerator.php
@@ -257,9 +257,13 @@ class UrlGenerator
 
         $parameters = $this->formatParametersForUrl($parameters);
 
-        $uri = preg_replace_callback('/\{(.*?)(:.*?)?(\{[0-9,]+\})?\}/', function ($m) use (&$parameters) {
-            return isset($parameters[$m[1]]) ? array_pull($parameters, $m[1]) : $m[0];
+        $uri = preg_replace_callback('/\[([^\]]*)\]$/', function ($matches) use ($uri, &$parameters) {
+            $uri = $this->replaceRouteParameters($matches[1], $parameters);
+
+            return ($matches[1] == $uri) ? '' : $uri;
         }, $uri);
+
+        $uri = $this->replaceRouteParameters($uri, $parameters);
 
         $uri = $this->to($uri, [], $secure);
 
@@ -332,6 +336,20 @@ class UrlGenerator
         }
 
         return $parameters;
+    }
+
+    /**
+     * Replace the route parameters with their parameter.
+     *
+     * @param  string  $route
+     * @param  array $parameters
+     * @return string
+     */
+    protected function replaceRouteParameters($route, &$parameters = [])
+    {
+        return preg_replace_callback('/\{(.*?)(:.*?)?(\{[0-9,]+\})?\}/', function ($m) use (&$parameters) {
+            return isset($parameters[$m[1]]) ? array_pull($parameters, $m[1]) : $m[0];
+        }, $route);
     }
 
     /**

--- a/tests/FullApplicationTest.php
+++ b/tests/FullApplicationTest.php
@@ -300,10 +300,22 @@ class FullApplicationTest extends TestCase
             //
         }]);
 
+        $app->router->get('/foo-bar/{baz}[/{boom}]', ['as' => 'optional', function () {
+            //
+        }]);
+
+        $app->router->get('/foo-bar/{baz:[0-9]+}[/{boom}]', ['as' => 'regex', function () {
+            //
+        }]);
+
         $this->assertEquals('http://lumen.laravel.com/something', url('something'));
         $this->assertEquals('http://lumen.laravel.com/foo-bar', route('foo'));
         $this->assertEquals('http://lumen.laravel.com/foo-bar/1/2', route('bar', ['baz' => 1, 'boom' => 2]));
         $this->assertEquals('http://lumen.laravel.com/foo-bar?baz=1&boom=2', route('foo', ['baz' => 1, 'boom' => 2]));
+        $this->assertEquals('http://lumen.laravel.com/foo-bar/1/2', route('optional', ['baz' => 1, 'boom' => 2]));
+        $this->assertEquals('http://lumen.laravel.com/foo-bar/1', route('optional', ['baz' => 1]));
+        $this->assertEquals('http://lumen.laravel.com/foo-bar/1/2', route('regex', ['baz' => 1, 'boom' => 2]));
+        $this->assertEquals('http://lumen.laravel.com/foo-bar/1', route('regex', ['baz' => 1]));
     }
 
     public function testGeneratingUrlsForRegexParameters()


### PR DESCRIPTION
This pull request adds support for optional parameters in the route url generator. This pull request was made to solve #539.

I've added a new regex which captures the string between the last square brackets, so it won't conflict with the route regex functionality. Within that string the route parameter placeholders will be replaced by their actual parameters.

If the `preg_replace_callback` function could not find any matches it will return the original string. I use that functionality to determine whether any placeholders were replaced. If not, it will be removed.