### PR TITLE
add InnoDB as default value

### DIFF
--- a/config/database.php
+++ b/config/database.php
@@ -51,7 +51,7 @@ return [
             'collation' => env('DB_COLLATION', 'utf8mb4_unicode_ci'),
             'prefix' => env('DB_PREFIX', ''),
             'strict' => env('DB_STRICT_MODE', true),
-            'engine' => env('DB_ENGINE', null),
+            'engine' => env('DB_ENGINE', 'InnoDB'),
             'timezone' => env('DB_TIMEZONE', '+00:00'),
         ],
 


### PR DESCRIPTION
We could not run migration if we have no default value DB_ENGINE