### PR TITLE
[5.7] Change application instance

### DIFF
--- a/src/Application.php
+++ b/src/Application.php
@@ -107,7 +107,7 @@ class Application extends Container
         static::setInstance($this);
 
         $this->instance('app', $this);
-        $this->instance('Laravel\Lumen\Application', $this);
+        $this->instance(static::class, $this);
 
         $this->instance('path', $this->path());
 


### PR DESCRIPTION
Hi, i have a some problems with my custom `Application` which extends from base `lumen\Application` and setup in `bootsrap/app.php`.

```php
// Custom\Application.php with custom methods
class Application extends \Laravel\Lumen\Application 

// app.php as base setup
use Custom\Application;

$app = new Application(
    realpath(__DIR__ . '/../')
);

```
This fix solve my problems and has back compatibility.
 What do you think?