### PR TITLE
[5.7]  Remove the "Schedule" class's constructor argument.

### DIFF
--- a/src/Console/Kernel.php
+++ b/src/Console/Kernel.php
@@ -95,7 +95,7 @@ class Kernel implements KernelContract
     protected function defineConsoleSchedule()
     {
         $this->app->instance(
-            'Illuminate\Console\Scheduling\Schedule', $schedule = new Schedule($this->app[Cache::class])
+            'Illuminate\Console\Scheduling\Schedule', $schedule = new Schedule
         );
 
         $this->schedule($schedule);


### PR DESCRIPTION
Remove the "Schedule" class's constructor argument. The "Cache" instance was passed to the "Schedule" class, which is not needed anymore, since the dependency in the "Schedule" class was removed sometime ago.

This also fixes: #844 