### PR TITLE
[5.7] Revert application instance binding change

### DIFF
--- a/src/Application.php
+++ b/src/Application.php
@@ -107,7 +107,7 @@ class Application extends Container
         static::setInstance($this);
 
         $this->instance('app', $this);
-        $this->instance(static::class, $this);
+        $this->instance('Laravel\Lumen\Application', $this);
 
         $this->instance('path', $this->path());
 


### PR DESCRIPTION
With Lumen 5.7.5 (50b908aa) the `Application` instance is no more bound to `\Laravel\Lumen\Application` but to the static class used.

This caused our existing application (was on 5.7.3 before) to throw an exception during bootstrapping (which is used for everything). I've easily replicated this in this [repository](https://github.com/krenor/lumen-framework-pull-840-bc-break) with a fresh Lumen installation. Try executing `php artisan` without it throwing:

```
In Container.php line 945:
  Target [Illuminate\Contracts\Debug\ExceptionHandler] is not instantiable.
```

This is fixable by aliasing the custom `Application` class.

```php
// bootstrap/app.php

$app->alias(\App\Application::class, \Laravel\Lumen\Application::class)
```

I've not had the time to investigate the cause of this but reverting the PR seems like the best idea as it **broke backwards compatibility**.