### PR TITLE
[5.7] Fix overwriting the Application class

### DIFF
--- a/src/Application.php
+++ b/src/Application.php
@@ -107,7 +107,7 @@ class Application extends Container
         static::setInstance($this);
 
         $this->instance('app', $this);
-        $this->instance(static::class, $this);
+        $this->instance(self::class, $this);
 
         $this->instance('path', $this->path());
 

--- a/tests/FullApplicationTest.php
+++ b/tests/FullApplicationTest.php
@@ -710,6 +710,13 @@ class FullApplicationTest extends TestCase
             $app->make(Illuminate\Contracts\Bus\Dispatcher::class)
         );
     }
+
+    public function testApplicationClassCanBeOverwritten()
+    {
+        $app = new LumenTestApplication();
+
+        $this->assertInstanceOf(LumenTestApplication::class, $app->make(Application::class));
+    }
 }
 
 class LumenTestService
@@ -791,6 +798,14 @@ class LumenTestAction
     public function __invoke($id)
     {
         return $id;
+    }
+}
+
+class LumenTestApplication extends Application
+{
+    public function version()
+    {
+        return 'Custom Lumen App';
     }
 }
 


### PR DESCRIPTION
See https://github.com/laravel/lumen-framework/pull/840. Added a test to verify the correct behavior.