### PR TITLE
[5.7] Fixed situation with overridden base Application-class

### DIFF
--- a/src/Application.php
+++ b/src/Application.php
@@ -108,6 +108,9 @@ class Application extends Container
 
         $this->instance('app', $this);
         $this->instance(self::class, $this);
+        if (self::class !== static::class) {
+            $this->instance(static::class, $this);
+        }
 
         $this->instance('path', $this->path());
 


### PR DESCRIPTION
My Application-class (**App\Helpers\Laravel\Lumen\Application**) override base-class (**Laravel\Lumen\Application**). The overriding was made in the middle of project life so part of the code expects **Laravel\Lumen\Application** and part - **App\Helpers\Laravel\Lumen\Application**.
