### PR TITLE
[5.7] Remove unnecessary code

### DIFF
--- a/src/Concerns/RoutesRequests.php
+++ b/src/Concerns/RoutesRequests.php
@@ -244,10 +244,6 @@ trait RoutesRequests
     {
         $this->currentRoute = $routeInfo;
 
-        $this['request']->setRouteResolver(function () {
-            return $this->currentRoute;
-        });
-
         $action = $routeInfo[1];
 
         // Pipe through route middleware...


### PR DESCRIPTION
The setRouteResolver() method is called when prepareRequest() method, so it's unnecessary to call in handleFoundRoute() method.

See https://github.com/laravel/lumen-framework/blob/v5.7.6/src/Application.php#L488-L490