### PR TITLE
[5.7] Fix equals expected and actual order in seeHeaders

### DIFF
--- a/src/Testing/Concerns/MakesHttpRequests.php
+++ b/src/Testing/Concerns/MakesHttpRequests.php
@@ -438,7 +438,7 @@ trait MakesHttpRequests
 
         if (! is_null($value)) {
             PHPUnit::assertEquals(
-                $headers->get($headerName), $value,
+                $value, $headers->get($headerName),
                 "Header [{$headerName}] was found, but value [{$headers->get($headerName)}] does not match [{$value}]."
             );
         }


### PR DESCRIPTION
`PHPUnit::assertEquals` first parameter should be the expected not the actual one