### PR TITLE
[5.7] Update Router.php

### DIFF
--- a/src/Routing/Router.php
+++ b/src/Routing/Router.php
@@ -270,15 +270,14 @@ class Router
     /**
      * Prepend the namespace onto the use clause.
      *
-     * @param $class
-     * @param $namespace
-     *
+     * @param  string  $class
+     * @param  string $namespace
      * @return string
      */
-    protected function prependGroupNamespace($class, $namespace)
+    protected function prependGroupNamespace($class, $namespace = null)
     {
         return $namespace !== null && strpos($class, '\\') !== 0
-            ? $namespace .'\\'. $class : $class;
+            ? $namespace.'\\'.$class : $class;
     }
 
     /**

--- a/src/Routing/Router.php
+++ b/src/Routing/Router.php
@@ -260,11 +260,25 @@ class Router
      */
     protected function mergeNamespaceGroup(array $action, $namespace = null)
     {
-        if (isset($namespace) && isset($action['uses'])) {
-            $action['uses'] = $namespace.'\\'.$action['uses'];
+        if (isset($namespace, $action['uses'])) {
+            $action['uses'] = $this->prependGroupNamespace($action['uses'], $namespace);
         }
 
         return $action;
+    }
+
+    /**
+     * Prepend the namespace onto the use clause.
+     *
+     * @param $class
+     * @param $namespace
+     *
+     * @return string
+     */
+    protected function prependGroupNamespace($class, $namespace)
+    {
+        return $namespace !== null && strpos($class, '\\') !== 0
+            ? $namespace .'\\'. $class : $class;
     }
 
     /**


### PR DESCRIPTION
Opposite to laravel, lumen at the moment always appends namespace, this PR makes lumen router to check, if class starts with backslash (same as laravel), if it starts with backslash, namespace shouldn't be applied to class name.