### PR TITLE
[5.7] Ability to define FQCN class names in routes file.

### DIFF
--- a/src/Routing/Router.php
+++ b/src/Routing/Router.php
@@ -270,15 +270,14 @@ class Router
     /**
      * Prepend the namespace onto the use clause.
      *
-     * @param $class
-     * @param $namespace
-     *
+     * @param  string  $class
+     * @param  string $namespace
      * @return string
      */
-    protected function prependGroupNamespace($class, $namespace)
+    protected function prependGroupNamespace($class, $namespace = null)
     {
         return $namespace !== null && strpos($class, '\\') !== 0
-            ? $namespace .'\\'. $class : $class;
+            ? $namespace.'\\'.$class : $class;
     }
 
     /**

--- a/src/Routing/Router.php
+++ b/src/Routing/Router.php
@@ -270,7 +270,7 @@ class Router
     /**
      * Prepend the namespace onto the use clause.
      *
-     * @param  string  $class
+     * @param  string $class
      * @param  string $namespace
      * @return string
      */

--- a/src/Routing/Router.php
+++ b/src/Routing/Router.php
@@ -260,11 +260,25 @@ class Router
      */
     protected function mergeNamespaceGroup(array $action, $namespace = null)
     {
-        if (isset($namespace) && isset($action['uses'])) {
-            $action['uses'] = $namespace.'\\'.$action['uses'];
+        if (isset($namespace, $action['uses'])) {
+            $action['uses'] = $this->prependGroupNamespace($action['uses'], $namespace);
         }
 
         return $action;
+    }
+
+    /**
+     * Prepend the namespace onto the use clause.
+     *
+     * @param $class
+     * @param $namespace
+     *
+     * @return string
+     */
+    protected function prependGroupNamespace($class, $namespace)
+    {
+        return $namespace !== null && strpos($class, '\\') !== 0
+            ? $namespace .'\\'. $class : $class;
     }
 
     /**

--- a/tests/FullApplicationTest.php
+++ b/tests/FullApplicationTest.php
@@ -668,6 +668,23 @@ class FullApplicationTest extends TestCase
         $this->assertEquals('Hello\\World\\Class@method', $route['action']['uses']);
     }
 
+    public function testNestedGroupNamespaceWithFQCNClassName()
+    {
+        $app = new Application();
+
+        $app->router->group(['namespace' => 'Hello'], function ($router) {
+            $router->group(['namespace' => 'World'], function ($router) {
+                $router->get('/world', '\Global\Namespaced\Class@method');
+            });
+        });
+
+        $routes = $app->router->getRoutes();
+
+        $route = $routes['GET/world'];
+
+        $this->assertEquals('\\Global\\Namespaced\\Class@method', $route['action']['uses']);
+    }
+
     public function testNestedGroupPrefixRequest()
     {
         $app = new Application();


### PR DESCRIPTION
At the moment lumen router is always appending namespace to route's "uses" defined controller.

Current example:
By defining UsersController lumen will apply default namespace from app.php "App\Http\Controllers"

```php
$router->get('profile', [
    'as' => 'profile', 'uses' => 'UsersController@index'
]);
```

And in final output you will get ```App\Http\Controllers\UsersController@index```
If extra groups were defined, they will also append their namespaces.

This change allows user to override default namespace appending, by defining class name in global namespace:

Example after PR:

```php
$router->get('profile', [
    'as' => 'profile', 'uses' => '\App\Http\Api\V1\Controllers\UsersController@index'
]);
```

In this example router won't append default namespace.

This makes lumen router to act same as laravel router is working at the moment. In laravel if you define class in global namespace, default namespace won't be applied. This gives you ability to override and extend routing logic

This isn't a breaking change, because by default routes are defined without leading backslash.

Please see submitted test with this PR.