### PR TITLE
[5.7] Rebind the request instance after dispatching through middleware

### DIFF
--- a/src/Concerns/RoutesRequests.php
+++ b/src/Concerns/RoutesRequests.php
@@ -158,7 +158,9 @@ trait RoutesRequests
         try {
             $this->boot();
 
-            return $this->sendThroughPipeline($this->middleware, function () use ($method, $pathInfo) {
+            return $this->sendThroughPipeline($this->middleware, function ($request) use ($method, $pathInfo) {
+                $this->instance(Request::class, $request);
+
                 if (isset($this->router->getRoutes()[$method.$pathInfo])) {
                     return $this->handleFoundRoute([true, $this->router->getRoutes()[$method.$pathInfo]['action'], []]);
                 }
@@ -413,7 +415,7 @@ trait RoutesRequests
                 ->then($then);
         }
 
-        return $then();
+        return $then($this->make('request'));
     }
 
     /**

--- a/tests/FullApplicationTest.php
+++ b/tests/FullApplicationTest.php
@@ -734,6 +734,17 @@ class FullApplicationTest extends TestCase
 
         $this->assertInstanceOf(LumenTestApplication::class, $app->make(Application::class));
     }
+
+    public function testRequestIsReboundOnDispatch()
+    {
+        $app = new Application();
+        $rebound = false;
+        $app->rebinding('request', function () use (&$rebound) {
+            $rebound = true;
+        });
+        $app->handle(Request::create('/'));
+        $this->assertTrue($rebound);
+    }
 }
 
 class LumenTestService


### PR DESCRIPTION
This PR rebinds the request after dispatching through middleware and before dispatching to the router, in the same way that Laravel does.  Resolves #856.