### PR TITLE
[5.7] Support app config for URL, with env var fallback

### DIFF
--- a/src/Testing/TestCase.php
+++ b/src/Testing/TestCase.php
@@ -55,7 +55,9 @@ abstract class TestCase extends BaseTestCase
 
         $this->app = $this->createApplication();
 
-        $this->app->make('url')->forceRootUrl(env('APP_URL', 'http://localhost/'));
+        $url = $this->app->make('config')->get('app.url', env('APP_URL', 'http://localhost'));
+        $this->app->make('url')->forceRootUrl($url);
+
 
         $this->app->boot();
     }

--- a/src/Testing/TestCase.php
+++ b/src/Testing/TestCase.php
@@ -58,7 +58,6 @@ abstract class TestCase extends BaseTestCase
         $url = $this->app->make('config')->get('app.url', env('APP_URL', 'http://localhost'));
         $this->app->make('url')->forceRootUrl($url);
 
-
         $this->app->boot();
     }
 


### PR DESCRIPTION
When the line setting the root URL was added, this forced use of the APP_URL env var, instead of using the same value that we can set in `config/app.php`, which can be any name for the environment variable. So if you had a different variable name such as BASE_URL (I suspect this is an artifact of an older version of lumen), and used that to set the `url` value in the app config file, the tests no longer worked, because the tests force you to use APP_URL. 

This change would default to whatever is set in app.php, with a fallback to the APP_URL value.