### PR TITLE
[5.8] Remove deprecated methods.

### DIFF
--- a/src/Routing/UrlGenerator.php
+++ b/src/Routing/UrlGenerator.php
@@ -183,30 +183,6 @@ class UrlGenerator
     }
 
     /**
-     * Get the scheme for a raw URL.
-     *
-     * @param  bool|null  $secure
-     * @return string
-     * @deprecated v5.5.x
-     */
-    protected function getScheme($secure)
-    {
-        return $this->formatScheme($secure);
-    }
-
-    /**
-     * Force the schema for URLs.
-     *
-     * @param  string  $schema
-     * @return void
-     * @deprecated v5.5.x
-     */
-    public function forceSchema($schema)
-    {
-        $this->forceScheme($schema);
-    }
-
-    /**
      * Force the schema for URLs.
      *
      * @param  string  $schema


### PR DESCRIPTION
It was deprecated to be inline with Laravel `UrlGenerator`

Signed-off-by: Mior Muhammad Zaki <crynobone@gmail.com>