### PR TITLE
[5.7] Fix incorrect request type during testing

### DIFF
--- a/src/Testing/Concerns/MakesHttpRequests.php
+++ b/src/Testing/Concerns/MakesHttpRequests.php
@@ -5,6 +5,7 @@ namespace Laravel\Lumen\Testing\Concerns;
 use Illuminate\Support\Str;
 use Illuminate\Http\Request;
 use PHPUnit\Framework\Assert as PHPUnit;
+use Laravel\Lumen\Http\Request as LumenRequest;
 use Symfony\Component\HttpFoundation\Request as SymfonyRequest;
 
 trait MakesHttpRequests
@@ -335,7 +336,7 @@ trait MakesHttpRequests
             $cookies, $files, $server, $content
         );
 
-        $this->app['request'] = Request::createFromBase($symfonyRequest);
+        $this->app['request'] = LumenRequest::createFromBase($symfonyRequest);
 
         return $this->response = $this->app->prepareResponse(
             $this->app->handle($this->app['request'])


### PR DESCRIPTION
When testing, the `call` method provides an instance of the Laravel Request class while this should be Lumen's own Request class.

Fixes https://github.com/laravel/lumen-framework/issues/881