### PR TITLE
[5.8] ConsoleServiceProvider implement DeferrableProvider contract

### DIFF
--- a/src/Console/ConsoleServiceProvider.php
+++ b/src/Console/ConsoleServiceProvider.php
@@ -8,7 +8,6 @@ use Illuminate\Auth\Console\ClearResetsCommand;
 use Illuminate\Cache\Console\CacheTableCommand;
 use Illuminate\Queue\Console\FailedTableCommand;
 use Illuminate\Database\Console\Seeds\SeedCommand;
-use Illuminate\Contracts\Support\DeferrableProvider;
 use Illuminate\Database\Console\Seeds\SeederMakeCommand;
 use Illuminate\Database\Console\Migrations\MigrateCommand;
 use Illuminate\Queue\Console\WorkCommand as QueueWorkCommand;
@@ -28,7 +27,7 @@ use Illuminate\Database\Console\Migrations\InstallCommand as MigrateInstallComma
 use Illuminate\Database\Console\Migrations\RefreshCommand as MigrateRefreshCommand;
 use Illuminate\Database\Console\Migrations\RollbackCommand as MigrateRollbackCommand;
 
-class ConsoleServiceProvider extends ServiceProvider implements DeferrableProvider
+class ConsoleServiceProvider extends ServiceProvider
 {
     /**
      * The commands to be registered.

--- a/src/Console/ConsoleServiceProvider.php
+++ b/src/Console/ConsoleServiceProvider.php
@@ -8,6 +8,7 @@ use Illuminate\Auth\Console\ClearResetsCommand;
 use Illuminate\Cache\Console\CacheTableCommand;
 use Illuminate\Queue\Console\FailedTableCommand;
 use Illuminate\Database\Console\Seeds\SeedCommand;
+use Illuminate\Contracts\Support\DeferrableProvider;
 use Illuminate\Database\Console\Seeds\SeederMakeCommand;
 use Illuminate\Database\Console\Migrations\MigrateCommand;
 use Illuminate\Queue\Console\WorkCommand as QueueWorkCommand;
@@ -27,15 +28,8 @@ use Illuminate\Database\Console\Migrations\InstallCommand as MigrateInstallComma
 use Illuminate\Database\Console\Migrations\RefreshCommand as MigrateRefreshCommand;
 use Illuminate\Database\Console\Migrations\RollbackCommand as MigrateRollbackCommand;
 
-class ConsoleServiceProvider extends ServiceProvider
+class ConsoleServiceProvider extends ServiceProvider implements DeferrableProvider
 {
-    /**
-     * Indicates if loading of the provider is deferred.
-     *
-     * @var bool
-     */
-    protected $defer = true;
-
     /**
      * The commands to be registered.
      *


### PR DESCRIPTION
In Laravel 5.8 the `$defer` boolean property on the provider is deprecated. Marking the provider as deferred now works via the `Illuminate\Contracts\Support\DeferrableProvider`contract.

https://laravel.com/docs/master/upgrade#deferred-service-providers