### PR TITLE
[5.8] Updated Lumen kernel to match the 5.8 kernel contract

### DIFF
--- a/src/Console/Kernel.php
+++ b/src/Console/Kernel.php
@@ -131,6 +131,18 @@ class Kernel implements KernelContract
     }
 
     /**
+     * Terminate the application.
+     *
+     * @param  \Symfony\Component\Console\Input\InputInterface  $input
+     * @param  int  $status
+     * @return void
+     */
+    public function terminate($input, $status)
+    {
+        $this->app->terminate();
+    }
+
+    /**
      * Define the application's command schedule.
      *
      * @param  \Illuminate\Console\Scheduling\Schedule  $schedule


### PR DESCRIPTION
In Laravel 5.8 `Illuminate/Contracts/Console/Kernel` had the `terminate` method added. Updated Lumen's Kernel to match this addition.