### PR TITLE
[5.8] Fix event dispatching in `event` helper

### DIFF
--- a/src/helpers.php
+++ b/src/helpers.php
@@ -190,7 +190,7 @@ if (! function_exists('env')) {
 
 if (! function_exists('event')) {
     /**
-     * Fire an event and call the listeners.
+     * Dispatch an event and call the listeners.
      *
      * @param  object|string  $event
      * @param  mixed   $payload
@@ -199,7 +199,7 @@ if (! function_exists('event')) {
      */
     function event($event, $payload = [], $halt = false)
     {
-        return app('events')->fire($event, $payload, $halt);
+        return app('events')->dispatch($event, $payload, $halt);
     }
 }
 


### PR DESCRIPTION
In laravel 5.8 method `fire` [was removed](https://github.com/laravel/framework/pull/26392), but lumen helper uses it.

```
event(new SomeEvent());
// PHP Error:  Call to undefined method Illuminate/Events/Dispatcher::fire()
```