### PR TITLE
[5.8] Removed should receive 'fire' from expectsEvents and withoutEvents

### DIFF
--- a/src/Testing/TestCase.php
+++ b/src/Testing/TestCase.php
@@ -192,7 +192,7 @@ abstract class TestCase extends BaseTestCase
 
         $mock = Mockery::spy('Illuminate\Contracts\Events\Dispatcher');
 
-        $mock->shouldReceive('fire', 'dispatch')->andReturnUsing(function ($called) use (&$events) {
+        $mock->shouldReceive('dispatch')->andReturnUsing(function ($called) use (&$events) {
             foreach ($events as $key => $event) {
                 if ((is_string($called) && $called === $event) ||
                     (is_string($called) && is_subclass_of($called, $event)) ||
@@ -224,7 +224,7 @@ abstract class TestCase extends BaseTestCase
     {
         $mock = Mockery::mock('Illuminate\Contracts\Events\Dispatcher');
 
-        $mock->shouldReceive('fire', 'dispatch');
+        $mock->shouldReceive('dispatch');
 
         $this->app->instance('events', $mock);
 


### PR DESCRIPTION
When mocking events it is still checking if the fire method is triggered but this method has been deprecated since Laravel 5.4 and removed since 5.8 so the test passes while the code will fail.
