### PR TITLE
Fixed PutenvAdapter in env helper

### DIFF
--- a/src/helpers.php
+++ b/src/helpers.php
@@ -161,7 +161,7 @@ if (! function_exists('env')) {
         static $variables;
 
         if ($variables === null) {
-            $variables = (new DotenvFactory([new EnvConstAdapter, new ServerConstAdapter, PutenvAdapter::class]))->createImmutable();
+            $variables = (new DotenvFactory([new EnvConstAdapter, new PutenvAdapter, new ServerConstAdapter]))->createImmutable();
         }
 
         return Option::fromValue($variables->get($key))


### PR DESCRIPTION
DotenvFactory only accepts instantiated adapters.

Also re-ordered to be the same as the Laravel implementation.