### PR TITLE
[5.8] Fix passing an empty string to the predis client

### DIFF
--- a/config/database.php
+++ b/config/database.php
@@ -115,14 +115,14 @@ return [
             'host' => env('REDIS_HOST', '127.0.0.1'),
             'password' => env('REDIS_PASSWORD', null),
             'port' => env('REDIS_PORT', 6379),
-            'database' => env('REDIS_DB', 0),
+            'database' => env('REDIS_DB', '0'),
         ],
 
         'cache' => [
             'host' => env('REDIS_HOST', '127.0.0.1'),
             'password' => env('REDIS_PASSWORD', null),
             'port' => env('REDIS_PORT', 6379),
-            'database' => env('REDIS_CACHE_DB', 1),
+            'database' => env('REDIS_CACHE_DB', '1'),
         ],
 
     ],


### PR DESCRIPTION
When specifying the index, make sure to put the 0 in quotes, otherwise it just gets evaluated as false which ends up passing an empty string to the predis client.
REDIS_DATABASE = 0 gets turned into "database":"" and gives ERR invalid DB index
REDIS_DATABASE = "0" results in "database":"0" and works