### PR TITLE
[5.8] Allow add folder in config

### DIFF
--- a/src/Application.php
+++ b/src/Application.php
@@ -645,6 +645,7 @@ class Application extends Container
                 return $path;
             }
         } else {
+            $name = str_replace('.', '/', $name);
             $appConfigPath = $this->basePath('config').'/'.$name.'.php';
 
             if (file_exists($appConfigPath)) {


### PR DESCRIPTION
We have folder inside `config` name `core`, then a config file name `menu.php`,

then in bootstrap `app.php`
```php
$app->configure('core.menu');
```

this is work in `laravel`, but when i decide to use `lumen` and `laravel` with one code base, in `laravel` we have `configurations` group by `folder` , then we notice `group by folder` cant load a config by `lumen`


using this will give a null

```php
dd(config('core'));
dd(config('core.menu'));
dd(config('core.menu.key'));
```

i hope this is helpful

Thanks regards
