### PR TITLE
[5.8] Allow filesystem factory to be dependency injectable

### DIFF
--- a/src/Application.php
+++ b/src/Application.php
@@ -899,6 +899,7 @@ class Application extends Container
             'Illuminate\Database\DatabaseManager' => 'db',
             'Illuminate\Contracts\Encryption\Encrypter' => 'encrypter',
             'Illuminate\Contracts\Events\Dispatcher' => 'events',
+            'Illuminate\Contracts\Filesystem\Factory' => 'filesystem',
             'Illuminate\Contracts\Hashing\Hasher' => 'hash',
             'log' => 'Psr\Log\LoggerInterface',
             'Illuminate\Contracts\Queue\Factory' => 'queue',

--- a/tests/FullApplicationTest.php
+++ b/tests/FullApplicationTest.php
@@ -610,6 +610,15 @@ class FullApplicationTest extends TestCase
         $this->assertSame('1234', $response->getContent());
     }
 
+    public function testCanResolveFilesystemFactoryFromContract()
+    {
+        $app = new Application();
+
+        $filesystem = $app['Illuminate\Contracts\Filesystem\Factory'];
+
+        $this->assertInstanceOf('Illuminate\Contracts\Filesystem\Factory', $filesystem);
+    }
+
     public function testCanResolveValidationFactoryFromContract()
     {
         $app = new Application();

--- a/tests/FullApplicationTest.php
+++ b/tests/FullApplicationTest.php
@@ -614,9 +614,9 @@ class FullApplicationTest extends TestCase
     {
         $app = new Application();
 
-        $filesystem = $app['Illuminate\Contracts\Filesystem\Factory'];
+        $filesystem = $app[Illuminate\Contracts\Filesystem\Factory::class];
 
-        $this->assertInstanceOf('Illuminate\Contracts\Filesystem\Factory', $filesystem);
+        $this->assertInstanceOf(Illuminate\Contracts\Filesystem\Factory::class, $filesystem);
     }
 
     public function testCanResolveValidationFactoryFromContract()


### PR DESCRIPTION
Lumen adds the filesystem factory as an available binding but as there is no alias the resolution fails.
https://github.com/laravel/lumen-framework/blob/32fa445283c182960891f4f21355376cf0ea3b31/src/Application.php#L937-L938