### PR TITLE
[5.8] Fix setting of APP_ENV variable in tests

### DIFF
--- a/src/Testing/TestCase.php
+++ b/src/Testing/TestCase.php
@@ -49,7 +49,7 @@ abstract class TestCase extends BaseTestCase
      */
     protected function refreshApplication()
     {
-        putenv('APP_ENV=testing');
+        $_ENV['APP_ENV'] = 'testing';
 
         Facade::clearResolvedInstances();
 


### PR DESCRIPTION
Environment variables are loaded into the `$_ENV` superglobal, not the `putenv` store. As is, this does not modify or update the _correct_ environment variable resulting in `app()->environment()` and other methods returning the "wrong" value.