### PR TITLE
Implement stream method in response factory

### DIFF
--- a/src/Http/ResponseFactory.php
+++ b/src/Http/ResponseFactory.php
@@ -7,6 +7,7 @@ use Illuminate\Http\Response;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Support\Traits\Macroable;
 use Symfony\Component\HttpFoundation\BinaryFileResponse;
+use Symfony\Component\HttpFoundation\StreamedResponse;
 
 class ResponseFactory
 {
@@ -37,6 +38,19 @@ class ResponseFactory
     public function json($data = [], $status = 200, array $headers = [], $options = 0)
     {
         return new JsonResponse($data, $status, $headers, $options);
+    }
+
+    /**
+     * Create a new streamed response instance.
+     *
+     * @param  \Closure  $callback
+     * @param  int  $status
+     * @param  array  $headers
+     * @return \Symfony\Component\HttpFoundation\StreamedResponse
+     */
+    public function stream($callback, $status = 200, array $headers = [])
+    {
+        return new StreamedResponse($callback, $status, $headers);
     }
 
     /**

--- a/tests/Http/ResponseFactoryTest.php
+++ b/tests/Http/ResponseFactoryTest.php
@@ -27,6 +27,18 @@ class ResponseFactoryTest extends TestCase
         $this->assertEquals(Response::HTTP_OK, $response->getStatusCode());
     }
 
+    public function testStreamDefaultResponse()
+    {
+        $responseFactory = new ResponseFactory();
+        $response = $responseFactory->stream(function () {
+            echo 'hello';
+        });
+
+        $this->assertInstanceOf('\Symfony\Component\HttpFoundation\Response', $response);
+        $this->assertFalse($response->getContent());
+        $this->assertEquals(Response::HTTP_OK, $response->getStatusCode());
+    }
+
     public function testDownloadDefaultResponse()
     {
         $temp = tempnam(sys_get_temp_dir(), 'fixture');
@@ -60,5 +72,15 @@ class ResponseFactoryTest extends TestCase
         $this->assertInstanceOf('\Symfony\Component\HttpFoundation\Response', $response);
         $this->assertEquals('{"hello":"world"}', $response->getContent());
         $this->assertEquals(Response::HTTP_OK, $response->getStatusCode());
+    }
+
+    public function testStreamDeferredCallback()
+    {
+        $responseFactory = new ResponseFactory();
+        $response = $responseFactory->stream(function () {
+            $this->fail();
+        });
+
+        $this->assertFalse($response->getContent());
     }
 }


### PR DESCRIPTION
The stream method creates a streamed response. A streamed response
defers content generation until the output is needed. It is useful
e.g. for large or long-running responses that could be incrementally
consumed by clients.

The implementation matches Illuminate's ResponseFactory contract
(Illuminate/Contracts/Routing/ResponseFactory).