### PR TITLE
[5.8] Add vlucas/phpdotenv as a dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -41,16 +41,15 @@
         "nikic/fast-route": "^1.3",
         "symfony/http-kernel": "^4.1",
         "symfony/http-foundation": "^4.1",
-        "symfony/var-dumper": "^4.1"
+        "symfony/var-dumper": "^4.1",
+        "vlucas/phpdotenv": "^3.3"
     },
     "require-dev": {
         "mockery/mockery": "^1.0",
-        "phpunit/phpunit": "^7.0|^8.0",
-        "vlucas/phpdotenv": "^3.3"
+        "phpunit/phpunit": "^7.0|^8.0"
     },
     "suggest": {
-        "laravel/tinker": "Required to use the tinker console command (^1.0).",
-        "vlucas/phpdotenv": "Required to use .env files (^3.3)."
+        "laravel/tinker": "Required to use the tinker console command (^1.0)."
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
`vlucas/phpdotenv` was introduced as a dependency in #879, but is not included in `require`. This causes a PHP "Class not Found" Fatal Error. 

This PR adds the dependency to `require` to solve the issue. 

The tests were not catching this because the dependency was in `require-dev`. 

Fixes #918


