### PR TITLE
[6.0] JSON response for exception handler when JSON is expected

### DIFF
--- a/src/Exceptions/Handler.php
+++ b/src/Exceptions/Handler.php
@@ -94,11 +94,14 @@ class Handler implements ExceptionHandler
 
         $fe = FlattenException::create($e);
 
-        $handler = new SymfonyExceptionHandler(env('APP_DEBUG', config('app.debug', false)));
+        if ($request->expectsJson()) {
+            $content = json_encode(['exception' => $e->getMessage()]);
+        } else {
+            $handler = new SymfonyExceptionHandler(env('APP_DEBUG', config('app.debug', false)));
+            $content = $this->decorate($handler->getContent($fe), $handler->getStylesheet($fe));
+        }
 
-        $decorated = $this->decorate($handler->getContent($fe), $handler->getStylesheet($fe));
-
-        $response = new Response($decorated, $fe->getStatusCode(), $fe->getHeaders());
+        $response = new Response($content, $fe->getStatusCode(), $fe->getHeaders());
 
         $response->exception = $e;
 


### PR DESCRIPTION
**Feature request:**
The exception handler renders an HTML page. Which probably makes sense for Laravel.
However, I'm using Lumen for an API.

The main problem I run into is when writing unit tests. For example, if the following test causes an exception in the code that is tested I receive an error because an attempt is being to parse the HTML error page as JSON.
```
$this->json('GET', '/user/1')->seeJsonEquals(['data' => ['id' => 1]]);
```


The error message I receive when running the test:
```
ErrorException: Invalid argument supplied for foreach()

vendor/illuminate/support/Arr.php:576
vendor/laravel/lumen-framework/src/Testing/Concerns/MakesHttpRequests.php:186
tests/Http/Controllers/User/UserControllerShowTest.php:16
vendor/phpunit/phpunit/src/TextUI/Command.php:203
vendor/phpunit/phpunit/src/TextUI/Command.php:156
```

I'm curious to get an opinion on this.
