### PR TITLE
[5.8] Add support for reportable, renderable, and responsable exceptions

### DIFF
--- a/src/Exceptions/Handler.php
+++ b/src/Exceptions/Handler.php
@@ -36,6 +36,10 @@ class Handler implements ExceptionHandler
             return;
         }
 
+        if (method_exists($e, 'report')) {
+            return $e->report();
+        }
+
         try {
             $logger = app('Psr\Log\LoggerInterface');
         } catch (Exception $ex) {

--- a/src/Exceptions/Handler.php
+++ b/src/Exceptions/Handler.php
@@ -86,6 +86,10 @@ class Handler implements ExceptionHandler
      */
     public function render($request, Exception $e)
     {
+        if (method_exists($e, 'render')) {
+            return $e->render($request);
+        }
+
         if ($e instanceof HttpResponseException) {
             return $e->getResponse();
         } elseif ($e instanceof ModelNotFoundException) {

--- a/src/Exceptions/Handler.php
+++ b/src/Exceptions/Handler.php
@@ -4,6 +4,7 @@ namespace Laravel\Lumen\Exceptions;
 
 use Exception;
 use Illuminate\Http\Response;
+use Illuminate\Contracts\Support\Responsable;
 use Illuminate\Validation\ValidationException;
 use Illuminate\Contracts\Debug\ExceptionHandler;
 use Illuminate\Auth\Access\AuthorizationException;
@@ -88,6 +89,8 @@ class Handler implements ExceptionHandler
     {
         if (method_exists($e, 'render')) {
             return $e->render($request);
+        } elseif ($e instanceof Responsable) {
+            return $e->toResponse($request);
         }
 
         if ($e instanceof HttpResponseException) {


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
This adds support for using the `report()` and `render()` methods on exceptions which is in [the documentation](https://laravel.com/docs/errors#renderable-exceptions) but not currently implemented in Lumen (as mentioned in #873).

This allows the exception handler class to check for an existing `report` or `render` method on the exception, mostly the same way as in Laravel's core handler ([report](https://github.com/laravel/framework/blob/7d2a5d0d9f6b4cc63840c24d555c1eef01c56b47/src/Illuminate/Foundation/Exceptions/Handler.php#L106-L108) and [render](https://github.com/laravel/framework/blob/7d2a5d0d9f6b4cc63840c24d555c1eef01c56b47/src/Illuminate/Foundation/Exceptions/Handler.php#L174-L176)).

It also adds support for exceptions that implement the [`Responsable`](https://github.com/laravel/framework/blob/7d2a5d0d9f6b4cc63840c24d555c1eef01c56b47/src/Illuminate/Contracts/Support/Responsable.php) contract.

However, I wasn't able to use the `Router::toResponse($request, $response);` call and the `$container` property doesn't exist on Lumen, so this implementation is closer to the older version of Laravel (5.5 I think?).

I would assume that this closes #873, however, they were using Lumen 5.7, so not sure.