### PR TITLE
[6.x] Fix the required Cache implementation parameter and db:wipe command registration

### DIFF
--- a/src/Console/ConsoleServiceProvider.php
+++ b/src/Console/ConsoleServiceProvider.php
@@ -16,6 +16,7 @@ use Illuminate\Database\Console\Migrations\RollbackCommand as MigrateRollbackCom
 use Illuminate\Database\Console\Migrations\StatusCommand as MigrateStatusCommand;
 use Illuminate\Database\Console\Seeds\SeedCommand;
 use Illuminate\Database\Console\Seeds\SeederMakeCommand;
+use Illuminate\Database\Console\WipeCommand;
 use Illuminate\Queue\Console\FailedTableCommand;
 use Illuminate\Queue\Console\FlushFailedCommand as FlushFailedQueueCommand;
 use Illuminate\Queue\Console\ForgetFailedCommand as ForgetFailedQueueCommand;
@@ -53,6 +54,7 @@ class ConsoleServiceProvider extends ServiceProvider
         'QueueRetry' => 'command.queue.retry',
         'QueueWork' => 'command.queue.work',
         'Seed' => 'command.seed',
+        'Wipe' => 'command.wipe',
         'ScheduleFinish' => 'Illuminate\Console\Scheduling\ScheduleFinishCommand',
         'ScheduleRun' => 'Illuminate\Console\Scheduling\ScheduleRunCommand',
     ];
@@ -303,8 +305,8 @@ class ConsoleServiceProvider extends ServiceProvider
      */
     protected function registerQueueRestartCommand()
     {
-        $this->app->singleton('command.queue.restart', function ($app) {
-            return new QueueRestartCommand($app['cache.store']);
+        $this->app->singleton('command.queue.restart', function () {
+            return new QueueRestartCommand;
         });
     }
 
@@ -315,8 +317,8 @@ class ConsoleServiceProvider extends ServiceProvider
      */
     protected function registerQueueRetryCommand()
     {
-        $this->app->singleton('command.queue.retry', function ($app) {
-            return new QueueRetryCommand($app['cache.store']);
+        $this->app->singleton('command.queue.retry', function () {
+            return new QueueRetryCommand;
         });
     }
 
@@ -328,7 +330,7 @@ class ConsoleServiceProvider extends ServiceProvider
     protected function registerQueueWorkCommand()
     {
         $this->app->singleton('command.queue.work', function ($app) {
-            return new QueueWorkCommand($app['queue.worker'], $app['cache.store']);
+            return new QueueWorkCommand($app['queue.worker']);
         });
     }
 
@@ -377,6 +379,18 @@ class ConsoleServiceProvider extends ServiceProvider
     {
         $this->app->singleton('command.seed', function ($app) {
             return new SeedCommand($app['db']);
+        });
+    }
+    
+    /**
+     * Register the command.
+     *
+     * @return void
+     */
+    protected function registerWipeCommand()
+    {
+        $this->app->singleton('command.wipe', function ($app) {
+            return new WipeCommand($app['db']);
         });
     }
 

--- a/src/Console/ConsoleServiceProvider.php
+++ b/src/Console/ConsoleServiceProvider.php
@@ -381,7 +381,7 @@ class ConsoleServiceProvider extends ServiceProvider
             return new SeedCommand($app['db']);
         });
     }
-    
+
     /**
      * Register the command.
      *
@@ -393,7 +393,7 @@ class ConsoleServiceProvider extends ServiceProvider
             return new WipeCommand($app['db']);
         });
     }
-    
+
     /**
      * Register the command.
      *

--- a/src/Console/ConsoleServiceProvider.php
+++ b/src/Console/ConsoleServiceProvider.php
@@ -393,7 +393,7 @@ class ConsoleServiceProvider extends ServiceProvider
             return new WipeCommand($app['db']);
         });
     }
-
+    
     /**
      * Register the command.
      *

--- a/src/Console/ConsoleServiceProvider.php
+++ b/src/Console/ConsoleServiceProvider.php
@@ -303,8 +303,8 @@ class ConsoleServiceProvider extends ServiceProvider
      */
     protected function registerQueueRestartCommand()
     {
-        $this->app->singleton('command.queue.restart', function () {
-            return new QueueRestartCommand;
+        $this->app->singleton('command.queue.restart', function ($app) {
+            return new QueueRestartCommand($app['cache.store']);
         });
     }
 
@@ -315,8 +315,8 @@ class ConsoleServiceProvider extends ServiceProvider
      */
     protected function registerQueueRetryCommand()
     {
-        $this->app->singleton('command.queue.retry', function () {
-            return new QueueRetryCommand;
+        $this->app->singleton('command.queue.retry', function ($app) {
+            return new QueueRetryCommand($app['cache.store']);
         });
     }
 
@@ -328,7 +328,7 @@ class ConsoleServiceProvider extends ServiceProvider
     protected function registerQueueWorkCommand()
     {
         $this->app->singleton('command.queue.work', function ($app) {
-            return new QueueWorkCommand($app['queue.worker']);
+            return new QueueWorkCommand($app['queue.worker'], $app['cache.store']);
         });
     }
 


### PR DESCRIPTION
Fixed the required Cache parameter for the QueueRetryCommand, QueueRestartCommand and QueueWorkCommand instantiated objects.

Register the db:wipe command as it is used by migrate:fresh