### PR TITLE
[6.x] Update references to translation methods

### DIFF
--- a/src/helpers.php
+++ b/src/helpers.php
@@ -330,7 +330,7 @@ if (! function_exists('trans')) {
             return app('translator');
         }
 
-        return app('translator')->trans($id, $replace, $locale);
+        return app('translator')->get($id, $replace, $locale);
     }
 }
 
@@ -361,7 +361,7 @@ if (! function_exists('trans_choice')) {
      */
     function trans_choice($id, $number, array $replace = [], $locale = null)
     {
-        return app('translator')->transChoice($id, $number, $replace, $locale);
+        return app('translator')->choice($id, $number, $replace, $locale);
     }
 }
 


### PR DESCRIPTION
In Laravel 6.x, the `Illuminate\Contracts\Translation\Translator::trans()` and `Illuminate\Contracts\Translation\Translator::transChoice()` methods were renamed to `get` and `choice`.

See: laravel/framework#29529

Closes #974

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
