### PR TITLE
[6.x] Change the default redis client

### DIFF
--- a/config/database.php
+++ b/config/database.php
@@ -107,7 +107,7 @@ return [
 
     'redis' => [
 
-        'client' => 'predis',
+        'client' => env('REDIS_CLIENT', 'phpredis'),
 
         'cluster' => env('REDIS_CLUSTER', false),
 


### PR DESCRIPTION
The same changes as in the Laravel 6.0.

During the upgrade process to Lumen 6.0 you are suggested to remove **predis** in favor to **phpredis**. But after removing `predis/predis` you get errors because Lumen has hardcoded predis in configs. This PR is made to fix it.