### PR TITLE
[6.x] Use redis cache connection by default

### DIFF
--- a/config/cache.php
+++ b/config/cache.php
@@ -72,7 +72,7 @@ return [
 
         'redis' => [
             'driver' => 'redis',
-            'connection' => env('CACHE_REDIS_CONNECTION', 'default'),
+            'connection' => env('CACHE_REDIS_CONNECTION', 'cache'),
         ],
 
     ],


### PR DESCRIPTION
Update default redis cache connection to use this specific connection.

The cache connection is defined in databases config (https://github.com/laravel/lumen-framework/blob/6.x/config/database.php#L121)