### PR TITLE
[6.x] Add null logging channel

### DIFF
--- a/config/logging.php
+++ b/config/logging.php
@@ -1,5 +1,6 @@
 <?php
 
+use Monolog\Handler\NullHandler;
 use Monolog\Handler\StreamHandler;
 use Monolog\Handler\SyslogUdpHandler;
 
@@ -86,6 +87,11 @@ return [
         'errorlog' => [
             'driver' => 'errorlog',
             'level' => 'debug',
+        ],
+
+        'null' => [
+            'driver' => 'monolog',
+            'handler' => NullHandler::class,
         ],
     ],
 


### PR DESCRIPTION
Include a new null logging channel for Lumen as also included for Laravel in https://github.com/laravel/laravel/pull/5106