### PR TITLE
[6.x] Allow multiple optional parameters in named routes

### DIFF
--- a/src/Routing/UrlGenerator.php
+++ b/src/Routing/UrlGenerator.php
@@ -235,7 +235,7 @@ class UrlGenerator
 
         $parameters = $this->formatParameters($parameters);
 
-        $uri = $this->replaceOptionalParts($uri,$parameters);
+        $uri = $this->replaceOptionalParts($uri, $parameters);
 
         $uri = $this->replaceRouteParameters($uri, $parameters);
 
@@ -249,7 +249,7 @@ class UrlGenerator
     }
 
     /**
-     * handle optional parts in a route
+     * handle optional parts in a route.
      *
      * @param string $uri
      * @param array  $parameters
@@ -266,7 +266,7 @@ class UrlGenerator
                     return '';
                 }
 
-                return (count($matches) === 3) ? $uri . $this->replaceOptionalParts($matches[2], $parameters) : $uri;
+                return (count($matches) === 3) ? $uri.$this->replaceOptionalParts($matches[2], $parameters) : $uri;
             },
             $uri);
     }

--- a/src/Routing/UrlGenerator.php
+++ b/src/Routing/UrlGenerator.php
@@ -235,11 +235,7 @@ class UrlGenerator
 
         $parameters = $this->formatParameters($parameters);
 
-        $uri = preg_replace_callback('/\[([^\]]*)\]$/', function ($matches) use ($uri, &$parameters) {
-            $uri = $this->replaceRouteParameters($matches[1], $parameters);
-
-            return ($matches[1] == $uri) ? '' : $uri;
-        }, $uri);
+        $uri = $this->replaceOptionalParts($uri,$parameters);
 
         $uri = $this->replaceRouteParameters($uri, $parameters);
 
@@ -250,6 +246,29 @@ class UrlGenerator
         }
 
         return $uri;
+    }
+
+    /**
+     * handle optional parts in a route
+     *
+     * @param string $uri
+     * @param array  $parameters
+     *
+     * @return string
+     */
+    protected function replaceOptionalParts(string $uri, array &$parameters):string
+    {
+        return preg_replace_callback(
+            '/\[([^\[\]]+)(\[?[^\]]+\]+)?\]$/',
+            function ($matches) use ($uri, &$parameters) {
+                $uri = $this->replaceRouteParameters($matches[1], $parameters);
+                if ($matches[1] === $uri) {
+                    return '';
+                }
+
+                return (count($matches) === 3) ? $uri . $this->replaceOptionalParts($matches[2], $parameters) : $uri;
+            },
+            $uri);
     }
 
     /**

--- a/tests/FullApplicationTest.php
+++ b/tests/FullApplicationTest.php
@@ -324,7 +324,6 @@ class FullApplicationTest extends TestCase
         $this->assertEquals('http://lumen.laravel.com/foo-bar/1/2', route('twoOptionals', ['baz' => 1, 'boom' => 2]));
         $this->assertEquals('http://lumen.laravel.com/foo-bar/1', route('twoOptionals', ['baz' => 1]));
         $this->assertEquals('http://lumen.laravel.com/foo-bar/1?quz=3', route('twoOptionals', ['baz' => 1, 'quz' => 3]));
-
         $this->assertEquals('http://lumen.laravel.com/foo-bar/1/2', route('twoOptionalsAndRegex', ['baz' => 1, 'boom' => 2]));
         $this->assertEquals('http://lumen.laravel.com/foo-bar/1', route('twoOptionalsAndRegex', ['baz' => 1]));
         $this->assertEquals('http://lumen.laravel.com/foo-bar/1?quz=3', route('twoOptionalsAndRegex', ['baz' => 1, 'quz' => 3]));

--- a/tests/FullApplicationTest.php
+++ b/tests/FullApplicationTest.php
@@ -302,11 +302,16 @@ class FullApplicationTest extends TestCase
         $app->router->get('/foo-bar/{baz}[/{boom}]', ['as' => 'optional', function () {
             //
         }]);
-
         $app->router->get('/foo-bar/{baz:[0-9]+}[/{boom}]', ['as' => 'regex', function () {
             //
         }]);
 
+        $app->router->get('/foo-bar/{baz}[/{boom}[/{qux}]]', ['as' => 'twoOptionals', function () {
+            //
+        }]);
+        $app->router->get('/foo-bar/{baz:[0-9]+}[/{boom}[/{qux}]]', ['as' => 'twoOptionalsAndRegex', function () {
+            //
+        }]);
         $this->assertEquals('http://lumen.laravel.com/something', url('something'));
         $this->assertEquals('http://lumen.laravel.com/foo-bar', route('foo'));
         $this->assertEquals('http://lumen.laravel.com/foo-bar/1/2', route('bar', ['baz' => 1, 'boom' => 2]));
@@ -315,6 +320,14 @@ class FullApplicationTest extends TestCase
         $this->assertEquals('http://lumen.laravel.com/foo-bar/1', route('optional', ['baz' => 1]));
         $this->assertEquals('http://lumen.laravel.com/foo-bar/1/2', route('regex', ['baz' => 1, 'boom' => 2]));
         $this->assertEquals('http://lumen.laravel.com/foo-bar/1', route('regex', ['baz' => 1]));
+        $this->assertEquals('http://lumen.laravel.com/foo-bar/1/2/3', route('twoOptionals', ['baz' => 1, 'boom' => 2, 'qux' => 3]));
+        $this->assertEquals('http://lumen.laravel.com/foo-bar/1/2', route('twoOptionals', ['baz' => 1, 'boom' => 2]));
+        $this->assertEquals('http://lumen.laravel.com/foo-bar/1', route('twoOptionals', ['baz' => 1]));
+        $this->assertEquals('http://lumen.laravel.com/foo-bar/1?quz=3', route('twoOptionals', ['baz' => 1, 'quz' => 3]));
+
+        $this->assertEquals('http://lumen.laravel.com/foo-bar/1/2', route('twoOptionalsAndRegex', ['baz' => 1, 'boom' => 2]));
+        $this->assertEquals('http://lumen.laravel.com/foo-bar/1', route('twoOptionalsAndRegex', ['baz' => 1]));
+        $this->assertEquals('http://lumen.laravel.com/foo-bar/1?quz=3', route('twoOptionalsAndRegex', ['baz' => 1, 'quz' => 3]));
     }
 
     public function testGeneratingUrlsForRegexParameters()


### PR DESCRIPTION
Closes #982.

**Before**
using `UrlGenerator->route()` on a Url like `/test[/{foo}[/{bar}]]`  generates a URL like `https://example.com/test[/{foo}[/{bar}]]`.

**After**
using `UrlGenerator->route()` on a Url like `/test[/{foo}[/{bar}]]`  generates a URL like `https://example.com/test`.

Parameters will also be handled in the correct order.
E.g.
`/test[/{foo}[/{bar}]]` with `foo = 1` returns `https://example.com/test/1`
`/test[/{foo}[/{bar}]]` with `foo = 1 and bar = 2 ` returns `https://example.com/test/1/2`
`/test[/{foo}[/{bar}]]` with `bar = 2 ` returns `https://example.com/test?bar=2`

