### PR TITLE
Add locale support for application

### DIFF
--- a/src/Application.php
+++ b/src/Application.php
@@ -939,6 +939,39 @@ class Application extends Container
     }
 
     /**
+     * Get the current application locale.
+     *
+     * @return string
+     */
+    public function getLocale()
+    {
+        return $this['config']->get('app.locale');
+    }
+
+    /**
+     * Set the current application locale.
+     *
+     * @param  string  $locale
+     * @return void
+     */
+    public function setLocale($locale)
+    {
+        $this['config']->set('app.locale', $locale);
+        $this['translator']->setLocale($locale);
+    }
+
+    /**
+     * Determine if application locale is the given locale.
+     *
+     * @param  string  $locale
+     * @return bool
+     */
+    public function isLocale($locale)
+    {
+        return $this->getLocale() == $locale;
+    }
+
+    /**
      * Register the core container aliases.
      *
      * @return void


### PR DESCRIPTION
Add locale methods to `\Laravel\Lumen\Application`
### Motivation
Without this methods, the trait `\Illuminate\Support\Traits\Localizable` cannot be used, but the `\Illuminate\Notifications\NotificationSender`uses it.

> If notifiable uses `\Illuminate\Contracts\Translation\HasLocalePreference` the sender throws an exception:
> **Call to undefined method \Laravel\Lumen\Application::getLocale()**
### Observations
Just copied methods from `\Illuminate\Foundation\Application` and removed the event dispatcher.