### PR TITLE
[6.x] YUI Library license fix

### DIFF
--- a/src/Exceptions/Handler.php
+++ b/src/Exceptions/Handler.php
@@ -186,7 +186,7 @@ class Handler implements ExceptionHandler
     <head>
         <meta name="robots" content="noindex,nofollow" />
         <style>
-            /* Copyright (c) 2010, Yahoo! Inc. All rights reserved. Code licensed under the BSD License: http://developer.yahoo.com/yui/license.html */
+            /* Copyright (c) 2010, Yahoo! Inc. All rights reserved. Code licensed under the BSD License: https://yuilibrary.com/license/ */
             html{color:#000;background:#FFF;}body,div,dl,dt,dd,ul,ol,li,h1,h2,h3,h4,h5,h6,pre,code,form,fieldset,legend,input,textarea,p,blockquote,th,td{margin:0;padding:0;}table{border-collapse:collapse;border-spacing:0;}fieldset,img{border:0;}address,caption,cite,code,dfn,em,strong,th,var{font-style:normal;font-weight:normal;}li{list-style:none;}caption,th{text-align:left;}h1,h2,h3,h4,h5,h6{font-size:100%;font-weight:normal;}q:before,q:after{content:'';}abbr,acronym{border:0;font-variant:normal;}sup{vertical-align:text-top;}sub{vertical-align:text-bottom;}input,textarea,select{font-family:inherit;font-size:inherit;font-weight:inherit;}input,textarea,select{*font-size:100%;}legend{color:#000;}
             html { background: #eee; padding: 10px }
             img { border: 0; }


### PR DESCRIPTION
The previous license URL weren't working. So I just found new license URL from their new library [homepage](https://yuilibrary.com/)

License type is still same but the URL was dead.