### PR TITLE
[6.x] Stop inappropriate env lookup in exception handler

### DIFF
--- a/src/Exceptions/Handler.php
+++ b/src/Exceptions/Handler.php
@@ -139,7 +139,7 @@ class Handler implements ExceptionHandler
     {
         $fe = FlattenException::create($e);
 
-        $handler = new SymfonyExceptionHandler(env('APP_DEBUG', config('app.debug', false)));
+        $handler = new SymfonyExceptionHandler(config('app.debug', false));
 
         $decorated = $this->decorate($handler->getContent($fe), $handler->getStylesheet($fe));
 
@@ -158,7 +158,7 @@ class Handler implements ExceptionHandler
      */
     protected function convertExceptionToArray(Exception $e)
     {
-        return env('APP_DEBUG', config('app.debug', false)) ? [
+        return config('app.debug', false) ? [
             'message' => $e->getMessage(),
             'exception' => get_class($e),
             'file' => $e->getFile(),


### PR DESCRIPTION
The only correct place to look is within the config. It is only coincidental that the `app.debug` config entry is usually populated to whatever `env('APP_DEBUG)` is.