### PR TITLE
[6.x] Removed more bad environment reading

### DIFF
--- a/src/Console/Kernel.php
+++ b/src/Console/Kernel.php
@@ -68,7 +68,7 @@ class Kernel implements KernelContract
      */
     protected function setRequestForConsole(Application $app)
     {
-        $uri = $app->make('config')->get('app.url', env('APP_URL', 'http://localhost'));
+        $uri = $app->make('config')->get('app.url', 'http://localhost');
 
         $components = parse_url($uri);
 

--- a/src/Testing/TestCase.php
+++ b/src/Testing/TestCase.php
@@ -53,7 +53,7 @@ abstract class TestCase extends BaseTestCase
 
         $this->app = $this->createApplication();
 
-        $url = $this->app->make('config')->get('app.url', env('APP_URL', 'http://localhost'));
+        $url = $this->app->make('config')->get('app.url', 'http://localhost');
 
         $this->app->make('url')->forceRootUrl($url);
 


### PR DESCRIPTION
The correct place to look is in the config file, which is what the code is already doing. There is no reason to read any environment variables. Setting the env variable will already set the value in the config file.