### PR TITLE
[7.x] Move timezone setting to app bootstrap file

### DIFF
--- a/src/Application.php
+++ b/src/Application.php
@@ -93,10 +93,6 @@ class Application extends Container
      */
     public function __construct($basePath = null)
     {
-        if (! empty(env('APP_TIMEZONE'))) {
-            date_default_timezone_set(env('APP_TIMEZONE', 'UTC'));
-        }
-
         $this->basePath = $basePath;
 
         $this->bootstrapContainer();


### PR DESCRIPTION
Laravel uses bootstrappers to load env variables and setup the timezone. Lumen currently sets up the env from the app `bootstrap/app.php` file and sets up the timezone as a side effect of constructing the application. This feels like a bit of a hack to me, and I think this behaviour would be best placed in the `bootstrap/app.php` file too.

---

Related to https://github.com/laravel/lumen/pull/141.