### PR TITLE
[6.x] Fix directory separator

### DIFF
--- a/src/helpers.php
+++ b/src/helpers.php
@@ -52,7 +52,7 @@ if (! function_exists('base_path')) {
      */
     function base_path($path = '')
     {
-        return app()->basePath().($path ? '/'.$path : $path);
+        return app()->basePath().($path ? DIRECTORY_SEPARATOR.$path : $path);
     }
 }
 


### PR DESCRIPTION
use directory separator constant instead of hard-coded string. breaks windows paths.