### PR TITLE
[6.x] Support changing pg database timezone

### DIFF
--- a/config/database.php
+++ b/config/database.php
@@ -66,6 +66,7 @@ return [
             'prefix' => env('DB_PREFIX', ''),
             'schema' => env('DB_SCHEMA', 'public'),
             'sslmode' => env('DB_SSL_MODE', 'prefer'),
+            'timezone' => env('DB_TIMEZONE', 'UTC'),
         ],
 
         'sqlsrv' => [


### PR DESCRIPTION
Since PostgresConnector supports it, allow to set DB timezone through
DB_TIMEZONE .env entry

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
