### PR TITLE
Mistake in \Laravel\Lumen\Exceptions\Handler::render() return type hint

### DIFF
--- a/src/Exceptions/Handler.php
+++ b/src/Exceptions/Handler.php
@@ -87,7 +87,7 @@ class Handler implements ExceptionHandler
      *
      * @param  \Illuminate\Http\Request  $request
      * @param  \Exception  $e
-     * @return \Illuminate\Http\Response
+     * @return \Symfony\Component\HttpFoundation\Response
      */
     public function render($request, Exception $e)
     {


### PR DESCRIPTION
It should match the return typehint in \Illuminate\Contracts\Debug\ExceptionHandler

This resolves `vimeo/psalm` always complaining about InvalidReturnStatement, LessSpecificImplementedReturnType, or ImplementedReturnTypeMismatch in your `app/Exceptions/Handler.php` no matter what you do.

Installed contract filename is  illuminate/contracts/Debug/ExceptionHandler.php, found here: https://github.com/laravel/framework/blob/6.x/src/Illuminate/Contracts/Debug/ExceptionHandler.php

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
