### PR TITLE
Allow use of static functions for routing methods

### DIFF
--- a/src/Concerns/RoutesRequests.php
+++ b/src/Concerns/RoutesRequests.php
@@ -280,7 +280,11 @@ trait RoutesRequests
 
         foreach ($action as $value) {
             if ($value instanceof Closure) {
-                $closure = $value->bindTo(new RoutingClosure);
+                try {
+                    $closure = $value->bindTo(new RoutingClosure);
+                } catch (\ErrorException $exception) {
+                    $closure = $value;
+                }
                 break;
             }
         }

--- a/tests/FullApplicationTest.php
+++ b/tests/FullApplicationTest.php
@@ -17,7 +17,7 @@ class FullApplicationTest extends TestCase
     {
         $app = new Application;
 
-        $app->router->get('/', function () {
+        $app->router->get('/', static function () {
             return response('Hello World');
         });
 


### PR DESCRIPTION
 - [x] It is a bug, considering that Laravel works with same code;
 - [x] Allow use of static functions for routing methods;
 - [x] Tests updated and passing; 
 - [x] Respecting code style;

Currently, routing methods allow only an anonymous non-static functions, like:

```php
$app->router->get('/', function () {
    return response('Hello World');
});
```

When we tried to use a static function, once that we do not need `$this` access in some cases, we will get an exception:

 > **ErrorException (E_WARNING)**
    Cannot bind an instance to a static closure

But sometimes we really do not need `$this` (as example of the test units), so we could do it that way:

```php
$app->router->get('/', static function () {
    return response('Hello World');
});
```

To resolve that, I have modified the `RoutesRequests.php` file to `try {}` to bind first, but in case of fail, it will use the own value itself, statically.

I have updated a testing to use `static function` and it passes. Other tests still uses non-static functions and keep working too.