### PR TITLE
Fix missing import

### DIFF
--- a/src/Application.php
+++ b/src/Application.php
@@ -2,6 +2,7 @@
 
 namespace Laravel\Lumen;
 
+use Exception;
 use Illuminate\Config\Repository as ConfigRepository;
 use Illuminate\Container\Container;
 use Illuminate\Filesystem\Filesystem;
@@ -16,7 +17,6 @@ use Nyholm\Psr7\Factory\Psr17Factory;
 use Nyholm\Psr7\Response as PsrResponse;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
-use Exception;
 use RuntimeException;
 use Symfony\Bridge\PsrHttpMessage\Factory\PsrHttpFactory;
 use Symfony\Component\HttpFoundation\Request as SymfonyRequest;

--- a/src/Application.php
+++ b/src/Application.php
@@ -16,6 +16,7 @@ use Nyholm\Psr7\Factory\Psr17Factory;
 use Nyholm\Psr7\Response as PsrResponse;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
+use Exception;
 use RuntimeException;
 use Symfony\Bridge\PsrHttpMessage\Factory\PsrHttpFactory;
 use Symfony\Component\HttpFoundation\Request as SymfonyRequest;


### PR DESCRIPTION
Instead of getting expected error `'Unable to resolve PSR request. Please install symfony/psr-http-message-bridge and nyholm/psr7.'`, this error is shown instead: `Class 'Laravel\\Lumen\\Exception' not found in src/Application.php:524`