### PR TITLE
[7.x] Fixed a typo

### DIFF
--- a/src/Testing/Concerns/MakesHttpRequests.php
+++ b/src/Testing/Concerns/MakesHttpRequests.php
@@ -414,12 +414,12 @@ trait MakesHttpRequests
     }
 
     /**
-     * Assert that the client response has a given code.
+     * Assert that the client response has a given status code.
      *
-     * @param  int  $code
+     * @param  int  $status
      * @return void
      */
-    public function assertResponseStatus($code)
+    public function assertResponseStatus($status)
     {
         $this->response->assertStatus($status);
     }


### PR DESCRIPTION
The typo causes errors in tests:
```
ErrorException: Undefined variable: status

/Users/user/project/vendor/laravel/lumen-framework/src/Testing/Concerns/MakesHttpRequests.php:424
```