### PR TITLE
add ramsey/uuid dependency,because of the illuminate/queue  rely on S…

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -40,6 +40,7 @@
         "illuminate/log": "^7.0",
         "dragonmantank/cron-expression": "^2.0",
         "nikic/fast-route": "^1.3",
+        "ramsey/uuid": "^3.7",
         "symfony/console": "^5.0",
         "symfony/error-handler": "^5.0",
         "symfony/http-kernel": "^5.0",


### PR DESCRIPTION
add ramsey/uuid dependency,because of the illuminate/queue  rely on Str::uuid,but  in illuminate/support package it was just an suggest package.