### PR TITLE
[7.x] Revert "Add ramsey/uuid dependency, because of the illuminate/queue"

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -40,7 +40,6 @@
         "illuminate/log": "^7.0",
         "dragonmantank/cron-expression": "^2.0",
         "nikic/fast-route": "^1.3",
-        "ramsey/uuid": "^3.7",
         "symfony/console": "^5.0",
         "symfony/error-handler": "^5.0",
         "symfony/http-kernel": "^5.0",


### PR DESCRIPTION
Reverts laravel/lumen-framework#1049. Replaced by https://github.com/laravel/framework/pull/31988.