### PR TITLE
[7.x] Add illuminate/console as a dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,6 +21,7 @@
         "illuminate/bus": "^7.0",
         "illuminate/cache": "^7.0",
         "illuminate/config": "^7.0",
+        "illuminate/console": "^7.0",
         "illuminate/container": "^7.0",
         "illuminate/contracts": "^7.0",
         "illuminate/database": "^7.0",


### PR DESCRIPTION
Even though Lumen references `illuminate/console` in it's code it doesn't directly depend on it. If `illuminate/queue` were to at some point drop it's `illuminate/console` dependency (I don't see why it would, but for argument's sake) Lumen would break.