### PR TITLE
[7.x] Add auth helper

### DIFF
--- a/src/helpers.php
+++ b/src/helpers.php
@@ -1,7 +1,7 @@
 <?php
 
-use Illuminate\Contracts\Auth\Factory as AuthFactory;
 use Illuminate\Container\Container;
+use Illuminate\Contracts\Auth\Factory as AuthFactory;
 use Illuminate\Contracts\Broadcasting\Factory as BroadcastFactory;
 use Illuminate\Contracts\Bus\Dispatcher;
 use Illuminate\Contracts\Debug\ExceptionHandler;

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -1,5 +1,6 @@
 <?php
 
+use Illuminate\Contracts\Auth\Factory as AuthFactory;
 use Illuminate\Container\Container;
 use Illuminate\Contracts\Broadcasting\Factory as BroadcastFactory;
 use Illuminate\Contracts\Bus\Dispatcher;
@@ -39,6 +40,23 @@ if (! function_exists('app')) {
         }
 
         return Container::getInstance()->make($make, $parameters);
+    }
+}
+
+if (! function_exists('auth')) {
+    /**
+     * Get the available auth instance.
+     *
+     * @param  string|null  $guard
+     * @return \Illuminate\Contracts\Auth\Factory|\Illuminate\Contracts\Auth\Guard|\Illuminate\Contracts\Auth\StatefulGuard
+     */
+    function auth($guard = null)
+    {
+        if (is_null($guard)) {
+            return app(AuthFactory::class);
+        }
+
+        return app(AuthFactory::class)->guard($guard);
     }
 }
 


### PR DESCRIPTION
Add missing auth helper. This solves a problem with using the `@auth` directive in views.

Fixes https://github.com/laravel/lumen-framework/issues/1066#issuecomment-612878719