### PR TITLE
[7.x] Fixed typo in method name

### DIFF
--- a/src/Concerns/RegistersExceptionHandlers.php
+++ b/src/Concerns/RegistersExceptionHandlers.php
@@ -48,7 +48,7 @@ trait RegistersExceptionHandlers
         });
 
         set_exception_handler(function ($e) {
-            $this->handleUncaughtException($e);
+            $this->handleException($e);
         });
 
         register_shutdown_function(function () {
@@ -112,7 +112,7 @@ trait RegistersExceptionHandlers
      * @param  \Throwable  $e
      * @return void
      */
-    protected function handleUncaughtException(Throwable $e)
+    protected function handleException(Throwable $e)
     {
         $handler = $this->resolveExceptionHandler();
 


### PR DESCRIPTION
Fixes https://github.com/laravel/lumen-framework/issues/1072.