### PR TITLE
Fix S3 endpoint url reference

### DIFF
--- a/config/filesystems.php
+++ b/config/filesystems.php
@@ -62,6 +62,7 @@ return [
             'region' => env('AWS_DEFAULT_REGION'),
             'bucket' => env('AWS_BUCKET'),
             'url' => env('AWS_URL'),
+            'endpoint' => env('AWS_ENDPOINT'),
         ],
 
     ],


### PR DESCRIPTION
AWS SDK doesn't really support the `url` config option, it needs to pass the `endpoint` option instead (https://docs.aws.amazon.com/sdk-for-php/v3/developer-guide/guide_configuration.html#endpoint).

Related changes from upstream
- https://github.com/laravel/laravel/pull/5267
- https://github.com/laravel/laravel/pull/5276

This should fix the case where people try to use a S3 compatible service with the default configuration provided by the lumen framework. Otherwise, one needs to add a custom ServiceProvider that uses the appropriate config options.