### PR TITLE
[7.x] Add providerIsLoaded method to Application

### DIFF
--- a/src/Application.php
+++ b/src/Application.php
@@ -154,6 +154,17 @@ class Application extends Container
     }
 
     /**
+     * Determine if the given service provider is loaded.
+     *
+     * @param  string  $provider
+     * @return bool
+     */
+    public function providerIsLoaded(string $provider)
+    {
+        return isset($this->loadedProviders[$provider]);
+    }
+
+    /**
      * Get or check the current application environment.
      *
      * @param  mixed


### PR DESCRIPTION
This PR is similar to https://github.com/laravel/framework/pull/33286

Here is how it works:
```php
if ($app->providerIsLoaded(OptionalServiceProvider::class)) {
    // Do something
}

if (! $app->providerIsLoaded(RequiredServiceProvider::class)) {
    // Throw exception
}
```

It might be useful in package development when you want to be 100% sure that provider is loaded. Or when you want to load some extra stuff if some optional providers are loaded.

Adding it to Lumen too because it will help us to avoid situations when package is working in Laravel, but not in Lumen:
https://github.com/laravel/framework/pull/33289#issuecomment-646965979