### PR TITLE
[7.x] Remove redundant return from void method

### DIFF
--- a/src/Application.php
+++ b/src/Application.php
@@ -213,7 +213,7 @@ class Application extends Container
      */
     public function registerDeferredProvider($provider)
     {
-        return $this->register($provider);
+        $this->register($provider);
     }
 
     /**


### PR DESCRIPTION
Follow up #1092 

Removing return because `register` method returns nothing.