### PR TITLE
[7.x] Replace string class names with ::class notation

### DIFF
--- a/src/Application.php
+++ b/src/Application.php
@@ -2,21 +2,43 @@
 
 namespace Laravel\Lumen;
 
+use Illuminate\Auth\AuthManager;
+use Illuminate\Auth\AuthServiceProvider;
+use Illuminate\Broadcasting\BroadcastServiceProvider;
+use Illuminate\Bus\BusServiceProvider;
+use Illuminate\Cache\CacheServiceProvider;
 use Illuminate\Config\Repository as ConfigRepository;
 use Illuminate\Container\Container;
+use Illuminate\Contracts\Auth\Access\Gate;
+use Illuminate\Contracts\Broadcasting\Broadcaster;
+use Illuminate\Contracts\Broadcasting\Factory;
+use Illuminate\Contracts\Bus\Dispatcher;
 use Illuminate\Contracts\Container\BindingResolutionException;
+use Illuminate\Database\DatabaseServiceProvider;
+use Illuminate\Database\MigrationServiceProvider;
+use Illuminate\Encryption\EncryptionServiceProvider;
+use Illuminate\Events\EventServiceProvider;
 use Illuminate\Filesystem\Filesystem;
+use Illuminate\Filesystem\FilesystemServiceProvider;
+use Illuminate\Hashing\HashServiceProvider;
 use Illuminate\Http\Request;
 use Illuminate\Log\LogManager;
+use Illuminate\Pagination\PaginationServiceProvider;
+use Illuminate\Queue\QueueServiceProvider;
 use Illuminate\Support\Composer;
 use Illuminate\Support\Facades\Facade;
 use Illuminate\Support\ServiceProvider;
 use Illuminate\Support\Str;
+use Illuminate\Translation\TranslationServiceProvider;
+use Illuminate\Validation\ValidationServiceProvider;
+use Illuminate\View\ViewServiceProvider;
+use Laravel\Lumen\Console\ConsoleServiceProvider;
 use Laravel\Lumen\Routing\Router;
 use Nyholm\Psr7\Factory\Psr17Factory;
 use Nyholm\Psr7\Response as PsrResponse;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
+use Psr\Log\LoggerInterface;
 use RuntimeException;
 use Symfony\Bridge\PsrHttpMessage\Factory\PsrHttpFactory;
 use Symfony\Component\HttpFoundation\Request as SymfonyRequest;
@@ -286,19 +308,19 @@ class Application extends Container
     protected function registerAuthBindings()
     {
         $this->singleton('auth', function () {
-            return $this->loadComponent('auth', 'Illuminate\Auth\AuthServiceProvider', 'auth');
+            return $this->loadComponent('auth', AuthServiceProvider::class, 'auth');
         });
 
         $this->singleton('auth.driver', function () {
-            return $this->loadComponent('auth', 'Illuminate\Auth\AuthServiceProvider', 'auth.driver');
+            return $this->loadComponent('auth', AuthServiceProvider::class, 'auth.driver');
         });
 
-        $this->singleton('Illuminate\Auth\AuthManager', function () {
-            return $this->loadComponent('auth', 'Illuminate\Auth\AuthServiceProvider', 'auth');
+        $this->singleton(AuthManager::class, function () {
+            return $this->loadComponent('auth', AuthServiceProvider::class, 'auth');
         });
 
-        $this->singleton('Illuminate\Contracts\Auth\Access\Gate', function () {
-            return $this->loadComponent('auth', 'Illuminate\Auth\AuthServiceProvider', 'Illuminate\Contracts\Auth\Access\Gate');
+        $this->singleton(Gate::class, function () {
+            return $this->loadComponent('auth', AuthServiceProvider::class, Gate::class);
         });
     }
 
@@ -309,12 +331,12 @@ class Application extends Container
      */
     protected function registerBroadcastingBindings()
     {
-        $this->singleton('Illuminate\Contracts\Broadcasting\Factory', function () {
-            return $this->loadComponent('broadcasting', 'Illuminate\Broadcasting\BroadcastServiceProvider', 'Illuminate\Contracts\Broadcasting\Factory');
+        $this->singleton(Factory::class, function () {
+            return $this->loadComponent('broadcasting', BroadcastServiceProvider::class, Factory::class);
         });
 
-        $this->singleton('Illuminate\Contracts\Broadcasting\Broadcaster', function () {
-            return $this->loadComponent('broadcasting', 'Illuminate\Broadcasting\BroadcastServiceProvider', 'Illuminate\Contracts\Broadcasting\Broadcaster');
+        $this->singleton(Broadcaster::class, function () {
+            return $this->loadComponent('broadcasting', BroadcastServiceProvider::class, Broadcaster::class);
         });
     }
 
@@ -325,10 +347,10 @@ class Application extends Container
      */
     protected function registerBusBindings()
     {
-        $this->singleton('Illuminate\Contracts\Bus\Dispatcher', function () {
-            $this->register('Illuminate\Bus\BusServiceProvider');
+        $this->singleton(Dispatcher::class, function () {
+            $this->register(BusServiceProvider::class);
 
-            return $this->make('Illuminate\Contracts\Bus\Dispatcher');
+            return $this->make(Dispatcher::class);
         });
     }
 
@@ -340,10 +362,10 @@ class Application extends Container
     protected function registerCacheBindings()
     {
         $this->singleton('cache', function () {
-            return $this->loadComponent('cache', 'Illuminate\Cache\CacheServiceProvider');
+            return $this->loadComponent('cache', CacheServiceProvider::class);
         });
         $this->singleton('cache.store', function () {
-            return $this->loadComponent('cache', 'Illuminate\Cache\CacheServiceProvider', 'cache.store');
+            return $this->loadComponent('cache', CacheServiceProvider::class, 'cache.store');
         });
     }
 
@@ -383,8 +405,8 @@ class Application extends Container
 
             return $this->loadComponent(
                 'database', [
-                    'Illuminate\Database\DatabaseServiceProvider',
-                    'Illuminate\Pagination\PaginationServiceProvider',
+                    DatabaseServiceProvider::class,
+                    PaginationServiceProvider::class,
                 ], 'db'
             );
         });
@@ -398,7 +420,7 @@ class Application extends Container
     protected function registerEncrypterBindings()
     {
         $this->singleton('encrypter', function () {
-            return $this->loadComponent('app', 'Illuminate\Encryption\EncryptionServiceProvider', 'encrypter');
+            return $this->loadComponent('app', EncryptionServiceProvider::class, 'encrypter');
         });
     }
 
@@ -410,7 +432,7 @@ class Application extends Container
     protected function registerEventBindings()
     {
         $this->singleton('events', function () {
-            $this->register('Illuminate\Events\EventServiceProvider');
+            $this->register(EventServiceProvider::class);
 
             return $this->make('events');
         });
@@ -436,13 +458,13 @@ class Application extends Container
     protected function registerFilesystemBindings()
     {
         $this->singleton('filesystem', function () {
-            return $this->loadComponent('filesystems', 'Illuminate\Filesystem\FilesystemServiceProvider', 'filesystem');
+            return $this->loadComponent('filesystems', FilesystemServiceProvider::class, 'filesystem');
         });
         $this->singleton('filesystem.disk', function () {
-            return $this->loadComponent('filesystems', 'Illuminate\Filesystem\FilesystemServiceProvider', 'filesystem.disk');
+            return $this->loadComponent('filesystems', FilesystemServiceProvider::class, 'filesystem.disk');
         });
         $this->singleton('filesystem.cloud', function () {
-            return $this->loadComponent('filesystems', 'Illuminate\Filesystem\FilesystemServiceProvider', 'filesystem.cloud');
+            return $this->loadComponent('filesystems', FilesystemServiceProvider::class, 'filesystem.cloud');
         });
     }
 
@@ -454,7 +476,7 @@ class Application extends Container
     protected function registerHashBindings()
     {
         $this->singleton('hash', function () {
-            $this->register('Illuminate\Hashing\HashServiceProvider');
+            $this->register(HashServiceProvider::class);
 
             return $this->make('hash');
         });
@@ -467,7 +489,7 @@ class Application extends Container
      */
     protected function registerLogBindings()
     {
-        $this->singleton('Psr\Log\LoggerInterface', function () {
+        $this->singleton(LoggerInterface::class, function () {
             $this->configure('logging');
 
             return new LogManager($this);
@@ -482,10 +504,10 @@ class Application extends Container
     protected function registerQueueBindings()
     {
         $this->singleton('queue', function () {
-            return $this->loadComponent('queue', 'Illuminate\Queue\QueueServiceProvider', 'queue');
+            return $this->loadComponent('queue', QueueServiceProvider::class, 'queue');
         });
         $this->singleton('queue.connection', function () {
-            return $this->loadComponent('queue', 'Illuminate\Queue\QueueServiceProvider', 'queue.connection');
+            return $this->loadComponent('queue', QueueServiceProvider::class, 'queue.connection');
         });
     }
 
@@ -569,7 +591,7 @@ class Application extends Container
 
             $this->instance('path.lang', $this->getLanguagePath());
 
-            $this->register('Illuminate\Translation\TranslationServiceProvider');
+            $this->register(TranslationServiceProvider::class);
 
             return $this->make('translator');
         });
@@ -609,7 +631,7 @@ class Application extends Container
     protected function registerValidatorBindings()
     {
         $this->singleton('validator', function () {
-            $this->register('Illuminate\Validation\ValidationServiceProvider');
+            $this->register(ValidationServiceProvider::class);
 
             return $this->make('validator');
         });
@@ -623,7 +645,7 @@ class Application extends Container
     protected function registerViewBindings()
     {
         $this->singleton('view', function () {
-            return $this->loadComponent('view', 'Illuminate\View\ViewServiceProvider');
+            return $this->loadComponent('view', ViewServiceProvider::class);
         });
     }
 
@@ -721,18 +743,18 @@ class Application extends Container
     public function withAliases($userAliases = [])
     {
         $defaults = [
-            'Illuminate\Support\Facades\Auth' => 'Auth',
-            'Illuminate\Support\Facades\Cache' => 'Cache',
-            'Illuminate\Support\Facades\DB' => 'DB',
-            'Illuminate\Support\Facades\Event' => 'Event',
-            'Illuminate\Support\Facades\Gate' => 'Gate',
-            'Illuminate\Support\Facades\Log' => 'Log',
-            'Illuminate\Support\Facades\Queue' => 'Queue',
-            'Illuminate\Support\Facades\Route' => 'Route',
-            'Illuminate\Support\Facades\Schema' => 'Schema',
-            'Illuminate\Support\Facades\Storage' => 'Storage',
-            'Illuminate\Support\Facades\URL' => 'URL',
-            'Illuminate\Support\Facades\Validator' => 'Validator',
+            \Illuminate\Support\Facades\Auth::class => 'Auth',
+            \Illuminate\Support\Facades\Cache::class => 'Cache',
+            \Illuminate\Support\Facades\DB::class => 'DB',
+            \Illuminate\Support\Facades\Event::class => 'Event',
+            \Illuminate\Support\Facades\Gate::class => 'Gate',
+            \Illuminate\Support\Facades\Log::class => 'Log',
+            \Illuminate\Support\Facades\Queue::class => 'Queue',
+            \Illuminate\Support\Facades\Route::class => 'Route',
+            \Illuminate\Support\Facades\Schema::class => 'Schema',
+            \Illuminate\Support\Facades\Storage::class => 'Storage',
+            \Illuminate\Support\Facades\URL::class => 'URL',
+            \Illuminate\Support\Facades\Validator::class => 'Validator',
         ];
 
         if (! static::$aliasesRegistered) {
@@ -891,8 +913,8 @@ class Application extends Container
 
         $this->configure('database');
 
-        $this->register('Illuminate\Database\MigrationServiceProvider');
-        $this->register('Laravel\Lumen\Console\ConsoleServiceProvider');
+        $this->register(MigrationServiceProvider::class);
+        $this->register(ConsoleServiceProvider::class);
     }
 
     /**
@@ -987,35 +1009,35 @@ class Application extends Container
     protected function registerContainerAliases()
     {
         $this->aliases = [
-            'Illuminate\Contracts\Foundation\Application' => 'app',
-            'Illuminate\Contracts\Auth\Factory' => 'auth',
-            'Illuminate\Contracts\Auth\Guard' => 'auth.driver',
-            'Illuminate\Contracts\Cache\Factory' => 'cache',
-            'Illuminate\Contracts\Cache\Repository' => 'cache.store',
-            'Illuminate\Contracts\Config\Repository' => 'config',
-            'Illuminate\Container\Container' => 'app',
-            'Illuminate\Contracts\Container\Container' => 'app',
-            'Illuminate\Database\ConnectionResolverInterface' => 'db',
-            'Illuminate\Database\DatabaseManager' => 'db',
-            'Illuminate\Contracts\Encryption\Encrypter' => 'encrypter',
-            'Illuminate\Contracts\Events\Dispatcher' => 'events',
-            'Illuminate\Contracts\Filesystem\Factory' => 'filesystem',
-            'Illuminate\Contracts\Filesystem\Filesystem' => 'filesystem.disk',
-            'Illuminate\Contracts\Filesystem\Cloud' => 'filesystem.cloud',
-            'Illuminate\Contracts\Hashing\Hasher' => 'hash',
-            'log' => 'Psr\Log\LoggerInterface',
-            'Illuminate\Contracts\Queue\Factory' => 'queue',
-            'Illuminate\Contracts\Queue\Queue' => 'queue.connection',
-            'Illuminate\Redis\RedisManager' => 'redis',
-            'Illuminate\Contracts\Redis\Factory' => 'redis',
-            'Illuminate\Redis\Connections\Connection' => 'redis.connection',
-            'Illuminate\Contracts\Redis\Connection' => 'redis.connection',
-            'request' => 'Illuminate\Http\Request',
-            'Laravel\Lumen\Routing\Router' => 'router',
-            'Illuminate\Contracts\Translation\Translator' => 'translator',
-            'Laravel\Lumen\Routing\UrlGenerator' => 'url',
-            'Illuminate\Contracts\Validation\Factory' => 'validator',
-            'Illuminate\Contracts\View\Factory' => 'view',
+            \Illuminate\Contracts\Foundation\Application::class => 'app',
+            \Illuminate\Contracts\Auth\Factory::class => 'auth',
+            \Illuminate\Contracts\Auth\Guard::class => 'auth.driver',
+            \Illuminate\Contracts\Cache\Factory::class => 'cache',
+            \Illuminate\Contracts\Cache\Repository::class => 'cache.store',
+            \Illuminate\Contracts\Config\Repository::class => 'config',
+            \Illuminate\Container\Container::class => 'app',
+            \Illuminate\Contracts\Container\Container::class => 'app',
+            \Illuminate\Database\ConnectionResolverInterface::class => 'db',
+            \Illuminate\Database\DatabaseManager::class => 'db',
+            \Illuminate\Contracts\Encryption\Encrypter::class => 'encrypter',
+            \Illuminate\Contracts\Events\Dispatcher::class => 'events',
+            \Illuminate\Contracts\Filesystem\Factory::class => 'filesystem',
+            \Illuminate\Contracts\Filesystem\Filesystem::class => 'filesystem.disk',
+            \Illuminate\Contracts\Filesystem\Cloud::class => 'filesystem.cloud',
+            \Illuminate\Contracts\Hashing\Hasher::class => 'hash',
+            'log' => \Psr\Log\LoggerInterface::class,
+            \Illuminate\Contracts\Queue\Factory::class => 'queue',
+            \Illuminate\Contracts\Queue\Queue::class => 'queue.connection',
+            \Illuminate\Redis\RedisManager::class => 'redis',
+            \Illuminate\Contracts\Redis\Factory::class => 'redis',
+            \Illuminate\Redis\Connections\Connection::class => 'redis.connection',
+            \Illuminate\Contracts\Redis\Connection::class => 'redis.connection',
+            'request' => \Illuminate\Http\Request::class,
+            \Laravel\Lumen\Routing\Router::class => 'router',
+            \Illuminate\Contracts\Translation\Translator::class => 'translator',
+            \Laravel\Lumen\Routing\UrlGenerator::class => 'url',
+            \Illuminate\Contracts\Validation\Factory::class => 'validator',
+            \Illuminate\Contracts\View\Factory::class => 'view',
         ];
     }
 
@@ -1027,47 +1049,47 @@ class Application extends Container
     public $availableBindings = [
         'auth' => 'registerAuthBindings',
         'auth.driver' => 'registerAuthBindings',
-        'Illuminate\Auth\AuthManager' => 'registerAuthBindings',
-        'Illuminate\Contracts\Auth\Guard' => 'registerAuthBindings',
-        'Illuminate\Contracts\Auth\Access\Gate' => 'registerAuthBindings',
-        'Illuminate\Contracts\Broadcasting\Broadcaster' => 'registerBroadcastingBindings',
-        'Illuminate\Contracts\Broadcasting\Factory' => 'registerBroadcastingBindings',
-        'Illuminate\Contracts\Bus\Dispatcher' => 'registerBusBindings',
+        \Illuminate\Auth\AuthManager::class => 'registerAuthBindings',
+        \Illuminate\Contracts\Auth\Guard::class => 'registerAuthBindings',
+        \Illuminate\Contracts\Auth\Access\Gate::class => 'registerAuthBindings',
+        \Illuminate\Contracts\Broadcasting\Broadcaster::class => 'registerBroadcastingBindings',
+        \Illuminate\Contracts\Broadcasting\Factory::class => 'registerBroadcastingBindings',
+        \Illuminate\Contracts\Bus\Dispatcher::class => 'registerBusBindings',
         'cache' => 'registerCacheBindings',
         'cache.store' => 'registerCacheBindings',
-        'Illuminate\Contracts\Cache\Factory' => 'registerCacheBindings',
-        'Illuminate\Contracts\Cache\Repository' => 'registerCacheBindings',
+        \Illuminate\Contracts\Cache\Factory::class => 'registerCacheBindings',
+        \Illuminate\Contracts\Cache\Repository::class => 'registerCacheBindings',
         'composer' => 'registerComposerBindings',
         'config' => 'registerConfigBindings',
         'db' => 'registerDatabaseBindings',
-        'Illuminate\Database\Eloquent\Factory' => 'registerDatabaseBindings',
+        \Illuminate\Database\Eloquent\Factory::class => 'registerDatabaseBindings',
         'filesystem' => 'registerFilesystemBindings',
         'filesystem.cloud' => 'registerFilesystemBindings',
         'filesystem.disk' => 'registerFilesystemBindings',
-        'Illuminate\Contracts\Filesystem\Cloud' => 'registerFilesystemBindings',
-        'Illuminate\Contracts\Filesystem\Filesystem' => 'registerFilesystemBindings',
-        'Illuminate\Contracts\Filesystem\Factory' => 'registerFilesystemBindings',
+        \Illuminate\Contracts\Filesystem\Cloud::class => 'registerFilesystemBindings',
+        \Illuminate\Contracts\Filesystem\Filesystem::class => 'registerFilesystemBindings',
+        \Illuminate\Contracts\Filesystem\Factory::class => 'registerFilesystemBindings',
         'encrypter' => 'registerEncrypterBindings',
-        'Illuminate\Contracts\Encryption\Encrypter' => 'registerEncrypterBindings',
+        \Illuminate\Contracts\Encryption\Encrypter::class => 'registerEncrypterBindings',
         'events' => 'registerEventBindings',
-        'Illuminate\Contracts\Events\Dispatcher' => 'registerEventBindings',
+        \Illuminate\Contracts\Events\Dispatcher::class => 'registerEventBindings',
         'files' => 'registerFilesBindings',
         'hash' => 'registerHashBindings',
-        'Illuminate\Contracts\Hashing\Hasher' => 'registerHashBindings',
+        \Illuminate\Contracts\Hashing\Hasher::class => 'registerHashBindings',
         'log' => 'registerLogBindings',
-        'Psr\Log\LoggerInterface' => 'registerLogBindings',
+        \Psr\Log\LoggerInterface::class => 'registerLogBindings',
         'queue' => 'registerQueueBindings',
         'queue.connection' => 'registerQueueBindings',
-        'Illuminate\Contracts\Queue\Factory' => 'registerQueueBindings',
-        'Illuminate\Contracts\Queue\Queue' => 'registerQueueBindings',
+        \Illuminate\Contracts\Queue\Factory::class => 'registerQueueBindings',
+        \Illuminate\Contracts\Queue\Queue::class => 'registerQueueBindings',
         'router' => 'registerRouterBindings',
-        'Psr\Http\Message\ServerRequestInterface' => 'registerPsrRequestBindings',
-        'Psr\Http\Message\ResponseInterface' => 'registerPsrResponseBindings',
+        \Psr\Http\Message\ServerRequestInterface::class => 'registerPsrRequestBindings',
+        \Psr\Http\Message\ResponseInterface::class => 'registerPsrResponseBindings',
         'translator' => 'registerTranslationBindings',
         'url' => 'registerUrlGeneratorBindings',
         'validator' => 'registerValidatorBindings',
-        'Illuminate\Contracts\Validation\Factory' => 'registerValidatorBindings',
+        \Illuminate\Contracts\Validation\Factory::class => 'registerValidatorBindings',
         'view' => 'registerViewBindings',
-        'Illuminate\Contracts\View\Factory' => 'registerViewBindings',
+        \Illuminate\Contracts\View\Factory::class => 'registerViewBindings',
     ];
 }

--- a/src/Console/ConsoleServiceProvider.php
+++ b/src/Console/ConsoleServiceProvider.php
@@ -6,6 +6,8 @@ use Illuminate\Auth\Console\ClearResetsCommand;
 use Illuminate\Cache\Console\CacheTableCommand;
 use Illuminate\Cache\Console\ClearCommand as CacheClearCommand;
 use Illuminate\Cache\Console\ForgetCommand as CacheForgetCommand;
+use Illuminate\Console\Scheduling\ScheduleFinishCommand;
+use Illuminate\Console\Scheduling\ScheduleRunCommand;
 use Illuminate\Database\Console\Migrations\FreshCommand as MigrateFreshCommand;
 use Illuminate\Database\Console\Migrations\InstallCommand as MigrateInstallCommand;
 use Illuminate\Database\Console\Migrations\MigrateCommand;
@@ -55,8 +57,8 @@ class ConsoleServiceProvider extends ServiceProvider
         'QueueWork' => 'command.queue.work',
         'Seed' => 'command.seed',
         'Wipe' => 'command.wipe',
-        'ScheduleFinish' => 'Illuminate\Console\Scheduling\ScheduleFinishCommand',
-        'ScheduleRun' => 'Illuminate\Console\Scheduling\ScheduleRunCommand',
+        'ScheduleFinish' => ScheduleFinishCommand::class,
+        'ScheduleRun' => ScheduleRunCommand::class,
     ];
 
     /**
@@ -401,7 +403,7 @@ class ConsoleServiceProvider extends ServiceProvider
      */
     protected function registerScheduleFinishCommand()
     {
-        $this->app->singleton('Illuminate\Console\Scheduling\ScheduleFinishCommand');
+        $this->app->singleton(ScheduleFinishCommand::class);
     }
 
     /**
@@ -411,7 +413,7 @@ class ConsoleServiceProvider extends ServiceProvider
      */
     protected function registerScheduleRunCommand()
     {
-        $this->app->singleton('Illuminate\Console\Scheduling\ScheduleRunCommand');
+        $this->app->singleton(ScheduleRunCommand::class);
     }
 
     /**

--- a/src/Routing/ProvidesConvenienceMethods.php
+++ b/src/Routing/ProvidesConvenienceMethods.php
@@ -4,6 +4,7 @@ namespace Laravel\Lumen\Routing;
 
 use Closure as BaseClosure;
 use Illuminate\Contracts\Auth\Access\Gate;
+use Illuminate\Contracts\Bus\Dispatcher;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Str;
@@ -181,7 +182,7 @@ trait ProvidesConvenienceMethods
      */
     public function dispatch($job)
     {
-        return app('Illuminate\Contracts\Bus\Dispatcher')->dispatch($job);
+        return app(Dispatcher::class)->dispatch($job);
     }
 
     /**
@@ -193,7 +194,7 @@ trait ProvidesConvenienceMethods
      */
     public function dispatchNow($job, $handler = null)
     {
-        return app('Illuminate\Contracts\Bus\Dispatcher')->dispatchNow($job, $handler);
+        return app(Dispatcher::class)->dispatchNow($job, $handler);
     }
 
     /**

--- a/src/Testing/TestCase.php
+++ b/src/Testing/TestCase.php
@@ -4,6 +4,7 @@ namespace Laravel\Lumen\Testing;
 
 use Exception;
 use Illuminate\Contracts\Auth\Authenticatable;
+use Illuminate\Contracts\Console\Kernel;
 use Illuminate\Support\Facades\Facade;
 use Mockery;
 use PHPUnit\Framework\TestCase as BaseTestCase;
@@ -188,7 +189,7 @@ abstract class TestCase extends BaseTestCase
     {
         $events = is_array($events) ? $events : func_get_args();
 
-        $mock = Mockery::spy('Illuminate\Contracts\Events\Dispatcher');
+        $mock = Mockery::spy(\Illuminate\Contracts\Events\Dispatcher::class);
 
         $mock->shouldReceive('dispatch')->andReturnUsing(function ($called) use (&$events) {
             foreach ($events as $key => $event) {
@@ -220,7 +221,7 @@ abstract class TestCase extends BaseTestCase
      */
     protected function withoutEvents()
     {
-        $mock = Mockery::mock('Illuminate\Contracts\Events\Dispatcher');
+        $mock = Mockery::mock(\Illuminate\Contracts\Events\Dispatcher::class);
 
         $mock->shouldReceive('dispatch');
 
@@ -249,7 +250,7 @@ abstract class TestCase extends BaseTestCase
         }
 
         $this->app->instance(
-            'Illuminate\Contracts\Bus\Dispatcher', $mock
+            \Illuminate\Contracts\Bus\Dispatcher::class, $mock
         );
 
         return $this;
@@ -269,7 +270,7 @@ abstract class TestCase extends BaseTestCase
         });
 
         $this->app->instance(
-            'Illuminate\Contracts\Bus\Dispatcher', $mock
+            \Illuminate\Contracts\Bus\Dispatcher::class, $mock
         );
 
         return $this;
@@ -310,7 +311,7 @@ abstract class TestCase extends BaseTestCase
      */
     public function artisan($command, $parameters = [])
     {
-        return $this->code = $this->app['Illuminate\Contracts\Console\Kernel']->call($command, $parameters);
+        return $this->code = $this->app[Kernel::class]->call($command, $parameters);
     }
 
     /**

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -5,6 +5,7 @@ use Illuminate\Contracts\Auth\Factory as AuthFactory;
 use Illuminate\Contracts\Broadcasting\Factory as BroadcastFactory;
 use Illuminate\Contracts\Bus\Dispatcher;
 use Illuminate\Contracts\Debug\ExceptionHandler;
+use Illuminate\Database\Eloquent\Factory;
 use Laravel\Lumen\Bus\PendingDispatch;
 
 if (! function_exists('abort')) {
@@ -202,7 +203,7 @@ if (! function_exists('factory')) {
     {
         app('db');
 
-        $factory = app('Illuminate\Database\Eloquent\Factory');
+        $factory = app(Factory::class);
 
         $arguments = func_get_args();
 

--- a/tests/Http/ResponseFactoryTest.php
+++ b/tests/Http/ResponseFactoryTest.php
@@ -1,8 +1,10 @@
 <?php
 
+use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Http\Response;
 use Laravel\Lumen\Http\ResponseFactory;
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Response as SymfonyResponse;
 
 class ResponseFactoryTest extends TestCase
 {
@@ -11,7 +13,7 @@ class ResponseFactoryTest extends TestCase
         $content = 'hello';
         $responseFactory = new ResponseFactory();
         $response = $responseFactory->make($content);
-        $this->assertInstanceOf('\Symfony\Component\HttpFoundation\Response', $response);
+        $this->assertInstanceOf(SymfonyResponse::class, $response);
         $this->assertEquals($content, $response->getContent());
         $this->assertEquals(Response::HTTP_OK, $response->getStatusCode());
     }
@@ -22,7 +24,7 @@ class ResponseFactoryTest extends TestCase
         $responseFactory = new ResponseFactory();
         $response = $responseFactory->json($content);
 
-        $this->assertInstanceOf('\Symfony\Component\HttpFoundation\Response', $response);
+        $this->assertInstanceOf(SymfonyResponse::class, $response);
         $this->assertEquals('{"hello":"world"}', $response->getContent());
         $this->assertEquals(Response::HTTP_OK, $response->getStatusCode());
     }
@@ -34,7 +36,7 @@ class ResponseFactoryTest extends TestCase
             echo 'hello';
         });
 
-        $this->assertInstanceOf('\Symfony\Component\HttpFoundation\Response', $response);
+        $this->assertInstanceOf(SymfonyResponse::class, $response);
         $this->assertFalse($response->getContent());
         $this->assertEquals(Response::HTTP_OK, $response->getStatusCode());
     }
@@ -49,7 +51,7 @@ class ResponseFactoryTest extends TestCase
         $responseFactory = new ResponseFactory();
         $response = $responseFactory->download($temp);
 
-        $this->assertInstanceOf('\Symfony\Component\HttpFoundation\Response', $response);
+        $this->assertInstanceOf(SymfonyResponse::class, $response);
         $this->assertFalse($response->getContent());
         $this->assertEquals(Response::HTTP_OK, $response->getStatusCode());
 
@@ -59,7 +61,7 @@ class ResponseFactoryTest extends TestCase
     public function testJsonResponseFromArrayableInterface()
     {
         // mock one Arrayable object
-        $content = $this->getMockBuilder('Illuminate\Contracts\Support\Arrayable')
+        $content = $this->getMockBuilder(Arrayable::class)
             ->setMethods(['toArray'])
             ->getMock();
         $content->expects($this->once())
@@ -69,7 +71,7 @@ class ResponseFactoryTest extends TestCase
         $responseFactory = new ResponseFactory();
         $response = $responseFactory->json($content);
 
-        $this->assertInstanceOf('\Symfony\Component\HttpFoundation\Response', $response);
+        $this->assertInstanceOf(SymfonyResponse::class, $response);
         $this->assertEquals('{"hello":"world"}', $response->getContent());
         $this->assertEquals(Response::HTTP_OK, $response->getStatusCode());
     }


### PR DESCRIPTION
This PR replaces string fully-qualified class names with `::class` notation and imports them if there are no naming conflicts. Didn't wanted to introduce aliases. I've added only `SymfonyResponse` alias in tests.