### PR TITLE
[7.x] Reorder register and boot methods

### DIFF
--- a/src/Providers/EventServiceProvider.php
+++ b/src/Providers/EventServiceProvider.php
@@ -21,6 +21,14 @@ class EventServiceProvider extends ServiceProvider
     protected $subscribe = [];
 
     /**
+     * {@inheritdoc}
+     */
+    public function register()
+    {
+        //
+    }
+
+    /**
      * Register the application's event listeners.
      *
      * @return void
@@ -38,14 +46,6 @@ class EventServiceProvider extends ServiceProvider
         foreach ($this->subscribe as $subscriber) {
             $events->subscribe($subscriber);
         }
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function register()
-    {
-        //
     }
 
     /**


### PR DESCRIPTION
This PR reordering `register` and `boot` methods in EventServiceProvider.

There are 2 reasons behind it:
1. `register` method is executing before the `boot` method
2. it's similar to the Laravel code base