### PR TITLE
[6.x] Add support for php 8

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        php: [7.2, 7.3, 7.4]
+        php: [7.2, 7.3, 7.4, 8.0]
 
     name: PHP ${{ matrix.php }}
 

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         }
     ],
     "require": {
-        "php": "^7.2",
+        "php": "^7.2.5|^8.0",
         "illuminate/auth": "^6.0",
         "illuminate/broadcasting": "^6.0",
         "illuminate/bus": "^6.0",
@@ -45,8 +45,8 @@
         "vlucas/phpdotenv": "^3.3"
     },
     "require-dev": {
-        "mockery/mockery": "^1.0",
-        "phpunit/phpunit": "^7.5|^8.0"
+        "mockery/mockery": "~1.3.3|^1.4.2",
+        "phpunit/phpunit": "^7.5.15|^8.4|^9.3.3"
     },
     "suggest": {
         "laravel/tinker": "Required to use the tinker console command (^2.0).",

--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,7 @@
         "illuminate/validation": "^6.0",
         "illuminate/view": "^6.0",
         "illuminate/log": "^6.0",
-        "dragonmantank/cron-expression": "^2.0",
+        "dragonmantank/cron-expression": "^2.3.1",
         "nikic/fast-route": "^1.3",
         "symfony/http-kernel": "^4.3",
         "symfony/http-foundation": "^4.3",


### PR DESCRIPTION
This PR will add php 8 support for Lumen 6.x. I used the same version constraints as in [Laravel 6.x](https://github.com/laravel/framework/blob/6.x/composer.json) for the relevant packages.