### PR TITLE
[8.x] Add support for php 8

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        php: [7.3, 7.4]
+        php: [7.3, 7.4, 8.0]
 
     name: PHP ${{ matrix.php }}
 

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         }
     ],
     "require": {
-        "php": "^7.3",
+        "php": "^7.3|^8.0",
         "illuminate/auth": "^8.0",
         "illuminate/broadcasting": "^8.0",
         "illuminate/bus": "^8.0",
@@ -41,7 +41,7 @@
         "illuminate/validation": "^8.0",
         "illuminate/view": "^8.0",
         "illuminate/log": "^8.0",
-        "dragonmantank/cron-expression": "^3.0",
+        "dragonmantank/cron-expression": "^3.0.2",
         "nikic/fast-route": "^1.3",
         "symfony/console": "^5.1",
         "symfony/error-handler": "^5.1",
@@ -52,8 +52,8 @@
         "vlucas/phpdotenv": "^5.2"
     },
     "require-dev": {
-        "mockery/mockery": "^1.3.1",
-        "phpunit/phpunit": "^8.4|^9.0"
+        "mockery/mockery": "^1.4.2",
+        "phpunit/phpunit": "^8.5.8|^9.3.3"
     },
     "suggest": {
         "laravel/tinker": "Required to use the tinker console command (^2.0).",


### PR DESCRIPTION
This PR will add php 8 support for Lumen 8.x. I used the same version constraints as in [Laravel 8.x](https://github.com/laravel/framework/blob/8.x/composer.json) for the relevant packages.