### PR TITLE
[7.x] Add support for php 8

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        php: [7.2, 7.3, 7.4]
+        php: [7.2, 7.3, 7.4, 8.0]
 
     name: PHP ${{ matrix.php }}
 

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         }
     ],
     "require": {
-        "php": "^7.2.5",
+         "php": "^7.2.5|^8.0",
         "illuminate/auth": "^7.0",
         "illuminate/broadcasting": "^7.0",
         "illuminate/bus": "^7.0",
@@ -39,7 +39,7 @@
         "illuminate/validation": "^7.0",
         "illuminate/view": "^7.0",
         "illuminate/log": "^7.0",
-        "dragonmantank/cron-expression": "^2.0",
+        "dragonmantank/cron-expression": "^2.3.1",
         "nikic/fast-route": "^1.3",
         "symfony/console": "^5.0",
         "symfony/error-handler": "^5.0",
@@ -50,8 +50,8 @@
         "vlucas/phpdotenv": "^4.0"
     },
     "require-dev": {
-        "mockery/mockery": "^1.0",
-        "phpunit/phpunit": "^8.4|^9.0"
+        "mockery/mockery": "~1.3.3|^1.4.2",
+        "phpunit/phpunit": "^8.4|^9.3.3"
     },
     "suggest": {
         "laravel/tinker": "Required to use the tinker console command (^2.0).",


### PR DESCRIPTION
This PR will add php 8 support for Lumen 7.x. I used the same version constraints as in [Laravel 7.x](https://github.com/laravel/framework/blob/7.x/composer.json) for the relevant packages.

This PR is currently only a draft as it is blocked by https://github.com/laravel/framework/pull/35045