### PR TITLE
[8.x] Avoid call_user_ functions

### DIFF
--- a/src/Console/ConsoleServiceProvider.php
+++ b/src/Console/ConsoleServiceProvider.php
@@ -97,7 +97,7 @@ class ConsoleServiceProvider extends ServiceProvider
     protected function registerCommands(array $commands)
     {
         foreach (array_keys($commands) as $command) {
-            call_user_func_array([$this, "register{$command}Command"], []);
+            $this->{"register{$command}Command"}();
         }
 
         $this->commands(array_values($commands));

--- a/src/Http/Request.php
+++ b/src/Http/Request.php
@@ -40,7 +40,7 @@ class Request extends BaseRequest
      */
     public function route($param = null, $default = null)
     {
-        $route = call_user_func($this->getRouteResolver());
+        $route = ($this->getRouteResolver())();
 
         if (is_null($route) || is_null($param)) {
             return $route;

--- a/src/Routing/Pipeline.php
+++ b/src/Routing/Pipeline.php
@@ -27,7 +27,7 @@ class Pipeline extends BasePipeline
                 try {
                     $slice = parent::carry();
 
-                    return call_user_func($slice($stack, $pipe), $passable);
+                    return ($slice($stack, $pipe))($passable);
                 } catch (Throwable $e) {
                     return $this->handleException($passable, $e);
                 }
@@ -45,7 +45,7 @@ class Pipeline extends BasePipeline
     {
         return function ($passable) use ($destination) {
             try {
-                return call_user_func($destination, $passable);
+                return $destination($passable);
             } catch (Throwable $e) {
                 return $this->handleException($passable, $e);
             }

--- a/src/Routing/ProvidesConvenienceMethods.php
+++ b/src/Routing/ProvidesConvenienceMethods.php
@@ -107,7 +107,7 @@ trait ProvidesConvenienceMethods
     protected function buildFailedValidationResponse(Request $request, array $errors)
     {
         if (isset(static::$responseBuilder)) {
-            return call_user_func(static::$responseBuilder, $request, $errors);
+            return (static::$responseBuilder)($request, $errors);
         }
 
         return new JsonResponse($errors, 422);
@@ -119,7 +119,7 @@ trait ProvidesConvenienceMethods
     protected function formatValidationErrors(Validator $validator)
     {
         if (isset(static::$errorFormatter)) {
-            return call_user_func(static::$errorFormatter, $validator);
+            return (static::$errorFormatter)($validator);
         }
 
         return $validator->errors()->getMessages();

--- a/src/Routing/Router.php
+++ b/src/Routing/Router.php
@@ -59,7 +59,7 @@ class Router
 
         $this->updateGroupStack($attributes);
 
-        call_user_func($callback, $this);
+        $callback($this);
 
         array_pop($this->groupStack);
     }

--- a/src/Testing/TestCase.php
+++ b/src/Testing/TestCase.php
@@ -118,7 +118,7 @@ abstract class TestCase extends BaseTestCase
 
         if ($this->app) {
             foreach ($this->beforeApplicationDestroyedCallbacks as $callback) {
-                call_user_func($callback);
+                $callback();
             }
 
             $this->app->flush();


### PR DESCRIPTION
None of these actually cause an issue for PHP 8 (unlike in laravel/framework), but never the less, we get better performance by not using those functions, and just using native calling syntax.