### PR TITLE
[9.x] Default Redis cache connection is wrong

### DIFF
--- a/config/cache.php
+++ b/config/cache.php
@@ -72,7 +72,7 @@ return [
 
         'redis' => [
             'driver' => 'redis',
-            'connection' => env('CACHE_REDIS_CONNECTION', 'default'),
+            'connection' => env('CACHE_REDIS_CONNECTION', 'cache'),
         ],
 
     ],


### PR DESCRIPTION
Cache clearing when using Redis would also clear the job queue as the default connection is used by both.

See https://github.com/laravel/laravel/blob/8.x/config/cache.php#L77

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
