### PR TITLE
[8.x] Adding missing headers when exception is of type HttpException.

### DIFF
--- a/src/Exceptions/Handler.php
+++ b/src/Exceptions/Handler.php
@@ -165,7 +165,8 @@ class Handler implements ExceptionHandler
     {
         $response = new Response(
             $this->renderExceptionWithSymfony($e, config('app.debug', false)),
-            $this->isHttpException($e) ? $e->getStatusCode() : 500
+            $this->isHttpException($e) ? $e->getStatusCode() : 500,
+            $this->isHttpException($e) ? $e->getHeaders() : []
         );
 
         $response->exception = $e;


### PR DESCRIPTION
Adding functionality that was present in 6.x to add headers to the response object in the exception handler, when the exception is an `HttpException`. This was a breaking issue for an application I develop for when I attempted to upgrade the Lumen version. It is not documented in the upgrade guide that this is new expected behavior.