### PR TITLE
[9.x] Add methods for ResponseFactory class

### DIFF
--- a/src/Http/ResponseFactory.php
+++ b/src/Http/ResponseFactory.php
@@ -41,6 +41,21 @@ class ResponseFactory
     }
 
     /**
+     * Create a new JSONP response instance.
+     *
+     * @param  string  $callback
+     * @param  mixed  $data
+     * @param  int  $status
+     * @param  array  $headers
+     * @param  int  $options
+     * @return \Illuminate\Http\JsonResponse
+     */
+    public function jsonp($callback, $data = [], $status = 200, array $headers = [], $options = 0)
+    {
+        return $this->json($data, $status, $headers, $options)->setCallback($callback);
+    }
+
+    /**
      * Create a new streamed response instance.
      *
      * @param  \Closure  $callback
@@ -51,6 +66,30 @@ class ResponseFactory
     public function stream($callback, $status = 200, array $headers = [])
     {
         return new StreamedResponse($callback, $status, $headers);
+    }
+
+    /**
+     * Create a new streamed response instance as a file download.
+     *
+     * @param  \Closure  $callback
+     * @param  string|null  $name
+     * @param  array  $headers
+     * @param  string|null  $disposition
+     * @return \Symfony\Component\HttpFoundation\StreamedResponse
+     */
+    public function streamDownload($callback, $name = null, array $headers = [], $disposition = 'attachment')
+    {
+        $response = new StreamedResponse($callback, 200, $headers);
+
+        if (! is_null($name)) {
+            $response->headers->set('Content-Disposition', $response->headers->makeDisposition(
+                $disposition,
+                $name,
+                $this->fallbackName($name)
+            ));
+        }
+
+        return $response;
     }
 
     /**
@@ -67,9 +106,32 @@ class ResponseFactory
         $response = new BinaryFileResponse($file, 200, $headers, true, $disposition);
 
         if (! is_null($name)) {
-            return $response->setContentDisposition($disposition, $name, str_replace('%', '', Str::ascii($name)));
+            return $response->setContentDisposition($disposition, $name, $this->fallbackName($name));
         }
 
         return $response;
+    }
+
+    /**
+     * Convert the string to ASCII characters that are equivalent to the given name.
+     *
+     * @param  string  $name
+     * @return string
+     */
+    protected function fallbackName($name)
+    {
+        return str_replace('%', '', Str::ascii($name));
+    }
+
+    /**
+     * Return the raw contents of a binary file.
+     *
+     * @param  \SplFileInfo|string  $file
+     * @param  array  $headers
+     * @return \Symfony\Component\HttpFoundation\BinaryFileResponse
+     */
+    public function file($file, array $headers = [])
+    {
+        return new BinaryFileResponse($file, 200, $headers);
     }
 }


### PR DESCRIPTION
The following new add methods copy from [Illuminate\Routing\ResponseFactory](https://github.com/laravel/framework/blob/master/src/Illuminate/Routing/ResponseFactory.php)(laravel-framework-master)

```
// Create a new JSONP response instance.
public function jsonp($callback, $data = [], $status = 200, array $headers = [], $options = 0);

// Create a new streamed response instance as a file download.
public function streamDownload($callback, $name = null, array $headers = [], $disposition = 'attachment');

// Return the raw contents of a binary file.
public function file($file, array $headers = [])

```

These are very practical methods help building web applications easier.