### PR TITLE
[8.x] Adding shouldDispatch() to PendingDispatch class

### DIFF
--- a/src/Bus/PendingDispatch.php
+++ b/src/Bus/PendingDispatch.php
@@ -2,7 +2,10 @@
 
 namespace Laravel\Lumen\Bus;
 
+use Illuminate\Container\Container;
 use Illuminate\Contracts\Bus\Dispatcher;
+use Illuminate\Contracts\Cache\Repository as Cache;
+use Illuminate\Contracts\Queue\ShouldBeUnique;
 
 class PendingDispatch
 {
@@ -51,12 +54,41 @@ class PendingDispatch
     }
 
     /**
+     * Determine if the job should be dispatched.
+     *
+     * @return bool
+     */
+    protected function shouldDispatch()
+    {
+        if (! $this->job instanceof ShouldBeUnique) {
+            return true;
+        }
+
+        $uniqueId = method_exists($this->job, 'uniqueId')
+                    ? $this->job->uniqueId()
+                    : ($this->job->uniqueId ?? '');
+
+        $cache = method_exists($this->job, 'uniqueVia')
+                    ? $this->job->uniqueVia()
+                    : Container::getInstance()->make(Cache::class);
+
+        return (bool) $cache->lock(
+            $key = 'laravel_unique_job:'.get_class($this->job).$uniqueId,
+            $this->job->uniqueFor ?? 0
+        )->get();
+    }
+
+    /**
      * Handle the object's destruction.
      *
      * @return void
      */
     public function __destruct()
     {
-        app(Dispatcher::class)->dispatch($this->job);
+        if (! $this->shouldDispatch()) {
+            return;
+        } else {
+            app(Dispatcher::class)->dispatch($this->job);
+        }
     }
 }


### PR DESCRIPTION
I came across an issue where jobs were dispatched multiple times while using the `ShouldBeUnique` interface. Releasing the cache lock was already implemented in `Illuminate\Queue\CallQueuedHandler` but setting the cache lock was not.

This pull request adds the `shouldDispatch()` method to `Laravel\Lumen\Bus\PendingDispatch` which is a copy from `Illuminate\Foundation\Bus\PendingDispatch` in https://github.com/laravel/framework/blob/8.x/src/Illuminate/Foundation/Bus/PendingDispatch.php

