### PR TITLE
fix empty response exception

### DIFF
--- a/src/Exceptions/Handler.php
+++ b/src/Exceptions/Handler.php
@@ -95,8 +95,8 @@ class Handler implements ExceptionHandler
      */
     public function render($request, Throwable $e)
     {
-        if (method_exists($e, 'render')) {
-            return $e->render($request);
+        if (method_exists($e, 'render') && $response = $e->render($request)) {
+            return $response;
         } elseif ($e instanceof Responsable) {
             return $e->toResponse($request);
         }


### PR DESCRIPTION
fix issue #1178 – empty response exception when response method of exception return void result (eg `Illuminate\View\ViewException`)
