### PR TITLE
Use standard reporting when exceptions don't handle reporting by them self

### DIFF
--- a/src/Exceptions/Handler.php
+++ b/src/Exceptions/Handler.php
@@ -44,7 +44,9 @@ class Handler implements ExceptionHandler
         }
 
         if (method_exists($e, 'report')) {
-            return $e->report();
+            if($e->report() !== false) {
+                return;
+            }
         }
 
         try {

--- a/src/Exceptions/Handler.php
+++ b/src/Exceptions/Handler.php
@@ -44,7 +44,7 @@ class Handler implements ExceptionHandler
         }
 
         if (method_exists($e, 'report')) {
-            if($e->report() !== false) {
+            if ($e->report() !== false) {
                 return;
             }
         }


### PR DESCRIPTION
Use standard reporting when exceptions don't handle reporting by them self.

Inspired by laravel/illuminate exception handler:

https://github.com/laravel/framework/blob/8.x/src/Illuminate/Foundation/Exceptions/Handler.php#L228