### PR TITLE
make failed job default config consistent with table structure artisan command creates

### DIFF
--- a/config/queue.php
+++ b/config/queue.php
@@ -79,6 +79,7 @@ return [
     */
 
     'failed' => [
+        'driver' => env('QUEUE_FAILED_DRIVER', 'database-uuids'),
         'database' => env('DB_CONNECTION', 'mysql'),
         'table' => env('QUEUE_FAILED_TABLE', 'failed_jobs'),
     ],


### PR DESCRIPTION
When using artisan commands for creating failed jobs table the failed_jobs table is created with "database-uuids" format but default framework config expects different schema.

PR suggests to make things consistent with [laravel](https://github.com/laravel/laravel/blob/8.x/config/queue.php#L88) and save future developers [encountering](https://laracasts.com/discuss/channels/lumen/uuid-on-queue-failed-jobs-is-empty) this problem.

