### PR TITLE
[8.x] Removed unused local variable

### DIFF
--- a/src/Http/Request.php
+++ b/src/Http/Request.php
@@ -58,7 +58,7 @@ class Request extends BaseRequest
      */
     public function fingerprint()
     {
-        if (! $route = $this->route()) {
+        if (! $this->route()) {
             throw new RuntimeException('Unable to generate fingerprint. Route unavailable.');
         }
 


### PR DESCRIPTION
Removed `$route` within the `fingerprint` function, the local variable is not used anywhere.