### PR TITLE
[8.x] Fixed DocBlocks

### DIFF
--- a/src/Concerns/RoutesRequests.php
+++ b/src/Concerns/RoutesRequests.php
@@ -85,7 +85,10 @@ trait RoutesRequests
     }
 
     /**
-     * {@inheritdoc}
+     * Dispatch request and return response
+     *
+     * @param  SymfonyRequest $request
+     * @return Response
      */
     public function handle(SymfonyRequest $request)
     {

--- a/src/Concerns/RoutesRequests.php
+++ b/src/Concerns/RoutesRequests.php
@@ -85,7 +85,7 @@ trait RoutesRequests
     }
 
     /**
-     * Dispatch request and return response
+     * Dispatch request and return response.
      *
      * @param  SymfonyRequest $request
      * @return Response

--- a/src/Concerns/RoutesRequests.php
+++ b/src/Concerns/RoutesRequests.php
@@ -57,7 +57,7 @@ trait RoutesRequests
     /**
      * Add new middleware to the application.
      *
-     * @param  Closure|array  $middleware
+     * @param  \Closure|array  $middleware
      * @return $this
      */
     public function middleware($middleware)
@@ -87,8 +87,8 @@ trait RoutesRequests
     /**
      * Dispatch request and return response.
      *
-     * @param  SymfonyRequest $request
-     * @return Response
+     * @param  \Symfony\Component\HttpFoundation\Request $request
+     * @return \Illuminate\Http\Response
      */
     public function handle(SymfonyRequest $request)
     {
@@ -104,7 +104,7 @@ trait RoutesRequests
     /**
      * Run the application and send the response.
      *
-     * @param  SymfonyRequest|null  $request
+     * @param  \Symfony\Component\HttpFoundation\Request|null  $request
      * @return void
      */
     public function run($request = null)
@@ -152,8 +152,8 @@ trait RoutesRequests
     /**
      * Dispatch the incoming request.
      *
-     * @param  SymfonyRequest|null  $request
-     * @return Response
+     * @param  \Symfony\Component\HttpFoundation\Request|null  $request
+     * @return \Illuminate\Http\Response
      */
     public function dispatch($request = null)
     {
@@ -198,7 +198,7 @@ trait RoutesRequests
     /**
      * Create a FastRoute dispatcher instance for the application.
      *
-     * @return Dispatcher
+     * @return \FastRoute\Dispatcher
      */
     protected function createDispatcher()
     {
@@ -433,7 +433,7 @@ trait RoutesRequests
      * Prepare the response for sending.
      *
      * @param  mixed  $response
-     * @return Response
+     * @return \Illuminate\Http\Response
      */
     public function prepareResponse($response)
     {

--- a/src/Concerns/RoutesRequests.php
+++ b/src/Concerns/RoutesRequests.php
@@ -396,7 +396,7 @@ trait RoutesRequests
     /**
      * Gather the full class names for the middleware short-cut string.
      *
-     * @param  string  $middleware
+     * @param  string|array  $middleware
      * @return array
      */
     protected function gatherMiddlewareClassNames($middleware)

--- a/src/Http/Redirector.php
+++ b/src/Http/Redirector.php
@@ -10,14 +10,14 @@ class Redirector
     /**
      * The application instance.
      *
-     * @var Application
+     * @var \Laravel\Lumen\Application
      */
     protected $app;
 
     /**
      * Create a new redirector instance.
      *
-     * @param  Application  $app
+     * @param  \Laravel\Lumen\Application  $app
      * @return void
      */
     public function __construct(Application $app)

--- a/src/Http/Request.php
+++ b/src/Http/Request.php
@@ -58,7 +58,7 @@ class Request extends BaseRequest
      */
     public function fingerprint()
     {
-        if (! $route = $this->route()) {
+        if (! $this->route()) {
             throw new RuntimeException('Unable to generate fingerprint. Route unavailable.');
         }
 

--- a/src/Routing/ProvidesConvenienceMethods.php
+++ b/src/Routing/ProvidesConvenienceMethods.php
@@ -102,7 +102,11 @@ trait ProvidesConvenienceMethods
     }
 
     /**
-     * {@inheritdoc}
+     * Build a response based on the given errors.
+     *
+     * @param  \Illuminate\Http\Request $request
+     * @param  array $errors
+     * @return \Illuminate\Http\JsonResponse|mixed
      */
     protected function buildFailedValidationResponse(Request $request, array $errors)
     {
@@ -114,7 +118,10 @@ trait ProvidesConvenienceMethods
     }
 
     /**
-     * {@inheritdoc}
+     * Format validation errors.
+     *
+     * @param  \Illuminate\Validation\Validator $validator
+     * @return array|mixed
      */
     protected function formatValidationErrors(Validator $validator)
     {

--- a/src/Routing/ProvidesConvenienceMethods.php
+++ b/src/Routing/ProvidesConvenienceMethods.php
@@ -58,7 +58,7 @@ trait ProvidesConvenienceMethods
      * @param  array  $customAttributes
      * @return array
      *
-     * @throws ValidationException
+     * @throws \Illuminate\Validation\ValidationException
      */
     public function validate(Request $request, array $rules, array $messages = [], array $customAttributes = [])
     {
@@ -92,7 +92,7 @@ trait ProvidesConvenienceMethods
      * @param  \Illuminate\Contracts\Validation\Validator  $validator
      * @return void
      *
-     * @throws ValidationException
+     * @throws \Illuminate\Validation\ValidationException
      */
     protected function throwValidationException(Request $request, $validator)
     {


### PR DESCRIPTION
- Replaced `@inheritDoc` -- missing parent member with doc comments 
- Updated docblock for `gatherMiddlewareClassNames` -- the `$middleware` parameter can handle arrays and the [`callLumenControllerWithMiddleware`](https://github.com/laravel/lumen-framework/blob/8.x/src/Concerns/RoutesRequests.php#L366) function passes an array