### PR TITLE
Cleanup tests on tearDown

### DIFF
--- a/src/Testing/TestCase.php
+++ b/src/Testing/TestCase.php
@@ -123,7 +123,7 @@ abstract class TestCase extends BaseTestCase
 
             $this->app->flush();
             $this->app = null;
-            
+
             $this->beforeApplicationDestroyedCallbacks = [];
         }
     }


### PR DESCRIPTION
`tearDown` is not clearing everything

I've noted that memory usage increases with each test case even if I clear everything in my tests.

This cleanup helps a bit with memory usage.

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

