### PR TITLE
improve render return type for render function

### DIFF
--- a/src/Exceptions/Handler.php
+++ b/src/Exceptions/Handler.php
@@ -91,7 +91,7 @@ class Handler implements ExceptionHandler
      *
      * @param  \Illuminate\Http\Request  $request
      * @param  \Throwable  $e
-     * @return \Symfony\Component\HttpFoundation\Response
+     * @return \Symfony\Component\HttpFoundation\Response|\Illuminate\Http\JsonResponse|\Illuminate\Http\Response
      *
      * @throws \Throwable
      */


### PR DESCRIPTION
responses from errors are Symfony's, but responses from function arre Illuminate's!

