### PR TITLE
[8.x] Fix PHP 8.1 deprecation issue

### DIFF
--- a/src/Routing/Router.php
+++ b/src/Routing/Router.php
@@ -148,7 +148,7 @@ class Router
         $oldPrefix = $old['prefix'] ?? null;
 
         if (isset($new['prefix'])) {
-            return trim($oldPrefix, '/').'/'.trim($new['prefix'], '/');
+            return trim($oldPrefix ?? '', '/').'/'.trim($new['prefix'], '/');
         }
 
         return $oldPrefix;


### PR DESCRIPTION
```
laravel.WARNING: trim(): Passing null to parameter #1 ($string) of type string is deprecated in /srv/api/vendor/laravel/lumen-framework/src/Routing/Router.php on line 151
```

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
