### PR TITLE
[8.x] Add Illuminate\Config\Repository::class as alias for config

### DIFF
--- a/src/Application.php
+++ b/src/Application.php
@@ -1015,6 +1015,7 @@ class Application extends Container
             \Illuminate\Contracts\Cache\Factory::class => 'cache',
             \Illuminate\Contracts\Cache\Repository::class => 'cache.store',
             \Illuminate\Contracts\Config\Repository::class => 'config',
+            \Illuminate\Config\Repository::class => 'config',
             \Illuminate\Container\Container::class => 'app',
             \Illuminate\Contracts\Container\Container::class => 'app',
             \Illuminate\Database\ConnectionResolverInterface::class => 'db',


### PR DESCRIPTION
In this PR, I added `Illuminate\Config\Repository::class` class as alias for `config` to the list of registered container aliases.

---
I discovered that `app()->make(Illuminate\Config\Repository::class);` does not return proper instance of config class (empty config values), actually found in PassportServiceProvider.
https://github.com/laravel/passport/blob/10.x/src/PassportServiceProvider.php#L268

LaravelPassport uses `Illuminate\Config\Repository::class` class for getting config values, so in this case if we are using Lumen, config is empty.
https://github.com/laravel/passport/blob/10.x/src/PassportServiceProvider.php#L8

I think we can do the same as Laravel do:
https://github.com/laravel/framework/blob/8.x/src/Illuminate/Foundation/Application.php#L1323

so
`app()->make(Illuminate\Config\Repository::class);`
and
`app()->make(Illuminate\Contracts\Config\Repository::class);`
will return the same config instance.