### PR TITLE
Use the correct alias while binding the request

### DIFF
--- a/src/Concerns/RoutesRequests.php
+++ b/src/Concerns/RoutesRequests.php
@@ -190,7 +190,7 @@ trait RoutesRequests
             $request = LumenRequest::capture();
         }
 
-        $this->instance(Request::class, $this->prepareRequest($request));
+        $this->instance('request', $this->prepareRequest($request));
 
         return [$request->getMethod(), '/'.trim($request->getPathInfo(), '/')];
     }


### PR DESCRIPTION
We are using behat as a test framework. 
There we need to create the request manually and then pass it to the `handle`  method on the `Application` (it's part of the RouteRequests trait).
This method calls the `dispatch` method with the same request.
Then within `dispatch`, the incoming request will be parsed and bound to the container on the abstract `Illuminate\Http\Request`.

Later on in the `sendThroughPipeline()` method, it calls `$this->make('request')`, which will create a new request and not use the one which was bound before.

Here are two options:
1. Just change the abstract in this one case
2. Use everywhere not `request` but the FQCN as `abstract`.

I went for option one as it is the least invasive approach.