### PR TITLE
[6.x] PHP 8 Support

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        php: [7.2, 7.3, 7.4]
+        php: [7.2, 7.3, 7.4, 8.0]
 
     name: PHP ${{ matrix.php }}
 

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         }
     ],
     "require": {
-        "php": "^7.2",
+        "php": "^7.2|^8.0",
         "illuminate/auth": "^6.0",
         "illuminate/broadcasting": "^6.0",
         "illuminate/bus": "^6.0",


### PR DESCRIPTION
For migrating from LTS version 6 to LTS version 9 there is no PHP version overlap.
Thanks to the work done here https://github.com/laravel/framework/pull/33388 and so much of the guts being shared, it seems safe to allow PHP 8 on lumen 6.x
This will help us with our migrations to PHP 8 so we can upgrade to Lumen 9 once it becomes available.
