### PR TITLE
Inject container and config into ExceptionHandler for better testability

### DIFF
--- a/src/Exceptions/Handler.php
+++ b/src/Exceptions/Handler.php
@@ -27,8 +27,7 @@ class Handler implements ExceptionHandler
     public function __construct(
         private Container $container,
         private Repository $config,
-    )
-    {
+    ) {
     }
 
     /**

--- a/tests/FullApplicationTest.php
+++ b/tests/FullApplicationTest.php
@@ -1,10 +1,12 @@
 <?php
 
+use Illuminate\Config\Repository;
 use Illuminate\Contracts\Debug\ExceptionHandler;
 use Illuminate\Contracts\Validation\Factory;
 use Illuminate\Http\Response;
 use Laravel\Lumen\Application;
 use Laravel\Lumen\Console\ConsoleServiceProvider;
+use Laravel\Lumen\Exceptions\Handler;
 use Laravel\Lumen\Http\Request;
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
@@ -234,8 +236,7 @@ class FullApplicationTest extends TestCase
     public function testNotFoundResponse()
     {
         $app = new Application;
-        $app->instance(ExceptionHandler::class, $mock = m::mock('Laravel\Lumen\Exceptions\Handler[report]'));
-        $mock->shouldIgnoreMissing();
+        $app->instance(ExceptionHandler::class, new Handler($app, new Repository()));
 
         $app->router->get('/', function () {
             return response('Hello World');
@@ -249,8 +250,7 @@ class FullApplicationTest extends TestCase
     public function testMethodNotAllowedResponse()
     {
         $app = new Application;
-        $app->instance(ExceptionHandler::class, $mock = m::mock('Laravel\Lumen\Exceptions\Handler[report]'));
-        $mock->shouldIgnoreMissing();
+        $app->instance(ExceptionHandler::class, new Handler($app, new Repository()));
 
         $app->router->post('/', function () {
             return response('Hello World');
@@ -279,8 +279,7 @@ class FullApplicationTest extends TestCase
     public function testUncaughtExceptionResponse()
     {
         $app = new Application;
-        $app->instance(ExceptionHandler::class, $mock = m::mock('Laravel\Lumen\Exceptions\Handler[report]'));
-        $mock->shouldIgnoreMissing();
+        $app->instance(ExceptionHandler::class, new Handler($app, new Repository()));
 
         $app->router->get('/', function () {
             throw new \RuntimeException('app exception');


### PR DESCRIPTION
First of all, thanks for all your efforts here :)

This PR injects the Container interface and the ConfigRepository interface into the constructor of the `Handler`.

This change allows easier testability when this class is overridden in a lumen application.
The current instantiation of the Handler is done via the Container, so there is no need to adapt anything.
I have adapted the Tests where the Handler was hacked and have replaced it with the real implementation.

If needed I can add some unit tests to the `Handler`.

