### PR TITLE
[9.x] Add langPath() method to Application

### DIFF
--- a/src/Application.php
+++ b/src/Application.php
@@ -832,6 +832,17 @@ class Application extends Container
     }
 
     /**
+     * Get the path to the language files.
+     *
+     * @param  string  $path
+     * @return string
+     */
+    public function langPath($path = '')
+    {
+        return $this->getLanguagePath().($path != '' ? DIRECTORY_SEPARATOR.$path : '');
+    }
+
+    /**
      * Get the storage path for the application.
      *
      * @param  string|null  $path


### PR DESCRIPTION
Fixes #1221. Same as #1222, but for 9.x, as 8.x is not supported anymore (where to find that information?).

