### PR TITLE
Set ContainerCommandLoader for lazy loading console commands

### DIFF
--- a/src/Console/Kernel.php
+++ b/src/Console/Kernel.php
@@ -209,7 +209,8 @@ class Kernel implements KernelContract
     {
         if (is_null($this->artisan)) {
             return $this->artisan = (new Artisan($this->app, $this->app->make('events'), $this->app->version()))
-                                ->resolveCommands($this->getCommands());
+                                ->resolveCommands($this->getCommands())
+                                ->setContainerCommandLoader();
         }
 
         return $this->artisan;


### PR DESCRIPTION
This is necessary for using native Laravel commands, such as _queue:prune-batches._