### PR TITLE
Fix `MakesHttpRequests::call()` return type

### DIFF
--- a/src/Testing/Concerns/MakesHttpRequests.php
+++ b/src/Testing/Concerns/MakesHttpRequests.php
@@ -344,7 +344,7 @@ trait MakesHttpRequests
      * @param  array  $files
      * @param  array  $server
      * @param  string  $content
-     * @return \Illuminate\Http\Response
+     * @return \Illuminate\Testing\TestResponse
      */
     public function call($method, $uri, $parameters = [], $cookies = [], $files = [], $server = [], $content = null)
     {


### PR DESCRIPTION
Static analysis of a method using `call()` fails with the following error:

```
 ------ ----------------------------------------------------------------------------------------------------------------------------------------------------- 
  Line   src/Testing/MakesGraphQLRequests.php (in context of class Tests\Unit\Testing\TestingTraitDummy)
 ------ ----------------------------------------------------------------------------------------------------------------------------------------------------- 
  100    Method Tests\Unit\Testing\TestingTraitDummy::multipartGraphQL() should return Illuminate\Testing\TestResponse but returns Illuminate\Http\Response.
 ------ -----------------------------------------------------------------------------------------------------------------------------------------------------
```

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
