### PR TITLE
Add resolve helper necessary for running migrations

### DIFF
--- a/src/helpers.php
+++ b/src/helpers.php
@@ -433,3 +433,17 @@ if (! function_exists('view')) {
         return $factory->make($view, $data, $mergeData);
     }
 }
+
+if (! function_exists('resolve')) {
+    /**
+     * Resolve a service from the container.
+     *
+     * @param  string  $name
+     * @param  array  $parameters
+     * @return mixed
+     */
+    function resolve($name, array $parameters = [])
+    {
+        return app($name, $parameters);
+    }
+}


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

Currently it's not possible to run any sort of migrations due to the missing helper function. This pull request adds the helper function which can also be found in `laravel/framework` package under path `src/Illuminate/Foundation/helpers.php`

For reference see the specific function below:
https://github.com/laravel/framework/blob/eee833e46de5301aa533ce1b7f5372d375b00fd8/src/Illuminate/Foundation/helpers.php#L701
