### PR TITLE
[9.x] Fix Call to undefined method Laravel\\Lumen\\Application::getFallbackLocale()

### DIFF
--- a/src/Application.php
+++ b/src/Application.php
@@ -990,6 +990,16 @@ class Application extends Container
     }
 
     /**
+     * Get the current application fallback locale.
+     *
+     * @return string
+     */
+    public function getFallbackLocale()
+    {
+        return $this['config']->get('app.fallback_locale');
+    }
+
+    /**
      * Set the current application locale.
      *
      * @param  string  $locale


### PR DESCRIPTION
https://github.com/laravel/lumen-framework/issues/1250