### PR TITLE
[9.x] Fixes view service provider terminating callbacks

### DIFF
--- a/src/Application.php
+++ b/src/Application.php
@@ -112,6 +112,13 @@ class Application extends Container
     public $router;
 
     /**
+     * The array of terminating callbacks.
+     *
+     * @var callable[]
+     */
+    protected $terminatingCallbacks = [];
+
+    /**
      * Create a new Lumen application instance.
      *
      * @param  string|null  $basePath
@@ -1020,6 +1027,35 @@ class Application extends Container
     public function isLocale($locale)
     {
         return $this->getLocale() == $locale;
+    }
+
+    /**
+     * Register a terminating callback with the application.
+     *
+     * @param  callable|string  $callback
+     * @return $this
+     */
+    public function terminating($callback)
+    {
+        $this->terminatingCallbacks[] = $callback;
+
+        return $this;
+    }
+
+    /**
+     * Terminate the application.
+     *
+     * @return void
+     */
+    public function terminate()
+    {
+        $index = 0;
+
+        while ($index < count($this->terminatingCallbacks)) {
+            $this->call($this->terminatingCallbacks[$index]);
+
+            $index++;
+        }
     }
 
     /**

--- a/src/Concerns/RoutesRequests.php
+++ b/src/Concerns/RoutesRequests.php
@@ -120,6 +120,8 @@ trait RoutesRequests
         if (count($this->middleware) > 0) {
             $this->callTerminableMiddleware($response);
         }
+
+        $this->app->terminate();
     }
 
     /**

--- a/src/Console/Kernel.php
+++ b/src/Console/Kernel.php
@@ -113,14 +113,18 @@ class Kernel implements KernelContract
         try {
             $this->app->boot();
 
-            return $this->getArtisan()->run($input, $output);
+            $status = $this->getArtisan()->run($input, $output);
         } catch (Throwable $e) {
             $this->reportException($e);
 
             $this->renderException($output, $e);
 
-            return 1;
+            $status = 1;
         }
+
+        $this->terminate($input, $status);
+
+        return $status;
     }
 
     /**
@@ -142,7 +146,7 @@ class Kernel implements KernelContract
      */
     public function terminate($input, $status)
     {
-        //
+        $this->app->terminate();
     }
 
     /**

--- a/tests/FullApplicationTest.php
+++ b/tests/FullApplicationTest.php
@@ -1,18 +1,18 @@
 <?php
 
 use Illuminate\Console\Command;
-use Illuminate\View\ViewServiceProvider;
 use Illuminate\Contracts\Debug\ExceptionHandler;
 use Illuminate\Contracts\Validation\Factory;
 use Illuminate\Http\Response;
+use Illuminate\View\ViewServiceProvider;
 use Laravel\Lumen\Application;
 use Laravel\Lumen\Console\ConsoleServiceProvider;
 use Laravel\Lumen\Http\Request;
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
-use Symfony\Component\HttpFoundation\Request as SymfonyRequest;
 use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Output\NullOutput;
+use Symfony\Component\HttpFoundation\Request as SymfonyRequest;
 
 class FullApplicationTest extends TestCase
 {


### PR DESCRIPTION
This pull request addresses https://github.com/laravel/lumen-framework/issues/1252, by ensuring `Application::terminating` is implemented and that it gets called on the console and HTTP layer.

Note, one difference between Lumen / Laravel on this implementation, is that the console `handle` is calling the `$app->terminate` on its `handle` method, as we can't modify the the `artisan` binaries that already exists on the user skeletons.