### PR TITLE
Fix middleware property setting in controller

### DIFF
--- a/src/Routing/Controller.php
+++ b/src/Routing/Controller.php
@@ -16,13 +16,16 @@ class Controller
     /**
      * Define a middleware on the controller.
      *
-     * @param  string  $middleware
+     * @param  \Closure|string  $middleware
      * @param  array  $options
      * @return void
      */
     public function middleware($middleware, array $options = [])
     {
-        $this->middleware[$middleware] = $options;
+        $this->middleware[] = [
+            'middleware' => $middleware,
+            'options' => $options
+        ];
     }
 
     /**


### PR DESCRIPTION
Hi, I found a bug for Lumen 9 version(other version may have same problem) when I was defining middleware in controller. I have a controller like this:
app/Http/Controllers/ExampleController.php:
```php
<?php

namespace App\Http\Controllers;

class ExampleController extends Controller
{
    /**
     * Create a new controller instance.
     *
     * @return void
     */
    public function __construct()
    {
        $this->middleware(function ($request, $next) {
            // some code ...
            return $next($request);
        });
    }
}
```
And when I'm using `app()->make('App\Http\Controllers\ExampleController')` for getting this controller middleware property when writing my own package, this got an error:
```
In Controller.php line 25:

  Illegal offset type
```
Because this middleware is a Closure. So I changed code and sent this pull request for it. Let me know if I am wrong or correct, thanks.
