### PR TITLE
Respect status code of AuthorizationException

### DIFF
--- a/src/Exceptions/Handler.php
+++ b/src/Exceptions/Handler.php
@@ -111,7 +111,7 @@ class Handler implements ExceptionHandler
         } elseif ($e instanceof ModelNotFoundException) {
             $e = new NotFoundHttpException($e->getMessage(), $e);
         } elseif ($e instanceof AuthorizationException) {
-            $e = new HttpException(403, $e->getMessage());
+            $e = new HttpException($e->status() ?? 403, $e->getMessage());
         } elseif ($e instanceof ValidationException && $e->getResponse()) {
             return $e->getResponse();
         }


### PR DESCRIPTION
The AuthorizationException handled here can have an optionally set status code. By default this status is `null`, so the previous code to map this to 403 seems correct. But if I throw a `(new AuthorizationException())->withStatus(401)` I would expect the exception handler to respect this code.