### PR TITLE
[10.x] Enforces at least composer 2.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,6 +16,7 @@
     ],
     "require": {
         "php": "^8.1",
+        "composer-runtime-api": "^2.2",
         "illuminate/auth": "^10.0",
         "illuminate/broadcasting": "^10.0",
         "illuminate/bus": "^10.0",


### PR DESCRIPTION
Same as https://github.com/laravel/framework/pull/46096, but for Lumen's framework.