### PR TITLE
fix: create alias only for classes that do not exist.

### DIFF
--- a/src/Application.php
+++ b/src/Application.php
@@ -790,7 +790,9 @@ class Application extends Container
             $merged = array_merge($defaults, $userAliases);
 
             foreach ($merged as $original => $alias) {
-                class_alias($original, $alias);
+                if (!class_exists($alias)) {
+                    class_alias($original, $alias);
+                }
             }
         }
     }

--- a/src/Application.php
+++ b/src/Application.php
@@ -790,7 +790,7 @@ class Application extends Container
             $merged = array_merge($defaults, $userAliases);
 
             foreach ($merged as $original => $alias) {
-                if (!class_exists($alias)) {
+                if (! class_exists($alias)) {
                     class_alias($original, $alias);
                 }
             }


### PR DESCRIPTION
Issue:
![image](https://github.com/laravel/lumen-framework/assets/16945969/c18b589e-3993-4149-9cc2-262f64c5d7ef)

Tests:
![image](https://github.com/laravel/lumen-framework/assets/16945969/a30c633b-1225-4c08-ad8f-3260e900e091)
