### PR TITLE
register ContextServiceProvider, fix php deprecations

### DIFF
--- a/config/database.php
+++ b/config/database.php
@@ -63,7 +63,7 @@ return [
             'engine' => env('DB_ENGINE'),
             'timezone' => env('DB_TIMEZONE', '+00:00'),
             'options' => extension_loaded('pdo_mysql') ? array_filter([
-                PDO::MYSQL_ATTR_SSL_CA => env('MYSQL_ATTR_SSL_CA'),
+                (PHP_VERSION_ID >= 80500 ? \Pdo\Mysql::ATTR_SSL_CA : \PDO::MYSQL_ATTR_SSL_CA) => env('MYSQL_ATTR_SSL_CA'),
             ]) : [],
         ],
 
@@ -84,7 +84,7 @@ return [
             'engine' => env('DB_ENGINE'),
             'timezone' => env('DB_TIMEZONE', '+00:00'),
             'options' => extension_loaded('pdo_mysql') ? array_filter([
-                PDO::MYSQL_ATTR_SSL_CA => env('MYSQL_ATTR_SSL_CA'),
+                (PHP_VERSION_ID >= 80500 ? \Pdo\Mysql::ATTR_SSL_CA : \PDO::MYSQL_ATTR_SSL_CA) => env('MYSQL_ATTR_SSL_CA'),
             ]) : [],
         ],
 

--- a/src/Application.php
+++ b/src/Application.php
@@ -519,6 +519,7 @@ class Application extends Container
     {
         $this->singleton(LoggerInterface::class, function () {
             $this->register(ContextServiceProvider::class);
+
             $this->configure('logging');
 
             return new LogManager($this);

--- a/src/Application.php
+++ b/src/Application.php
@@ -22,6 +22,7 @@ use Illuminate\Filesystem\Filesystem;
 use Illuminate\Filesystem\FilesystemServiceProvider;
 use Illuminate\Hashing\HashServiceProvider;
 use Illuminate\Http\Request;
+use Illuminate\Log\Context\ContextServiceProvider;
 use Illuminate\Log\LogManager;
 use Illuminate\Pagination\PaginationServiceProvider;
 use Illuminate\Queue\QueueServiceProvider;
@@ -517,6 +518,7 @@ class Application extends Container
     protected function registerLogBindings()
     {
         $this->singleton(LoggerInterface::class, function () {
+            $this->register(ContextServiceProvider::class);
             $this->configure('logging');
 
             return new LogManager($this);

--- a/tests/Testing/Concerns/MakesHttpRequestsTest.php
+++ b/tests/Testing/Concerns/MakesHttpRequestsTest.php
@@ -10,6 +10,8 @@ class MakesHttpRequestsTest extends TestCase
 {
     use MakesHttpRequests;
 
+    protected $app;
+
     public function testReceiveJson()
     {
         $this->app = new Application;


### PR DESCRIPTION
1. Currently, all logs are getting sent to emergency channel because `ContextServiceProvider` introduced here: https://github.com/laravel/framework/pull/54851 is not registered. So, register it.
2. fix php PDO deprecation [same as in laravel](https://github.com/laravel/laravel/commit/8500bcc5bdded80636ea8ea67a3522252c04f0f0)
4. fix deprecated dynamically set `$app` property in test